### PR TITLE
Getting Started Steps and Build Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,44 @@
 
 ## Getting Started
 
-To check the files currently managed by Git LFS
+To serve a local version of the 3Blue1Brown.com start by installing [Hugo](https://gohugo.io/getting-started/installing/) and [Git LFS](https://git-lfs.github.com/). If on Windows or donwloading the tarball, make sure to download the extended version of Hugo. On macOS this can be done with [Homebrew](https://brew.sh/) using the two commands:
 
 ```sh
-git lfs ls-files --all
+brew install hugo
 ```
+
+```sh
+brew install git-lfs
+```
+
+If installing Git LFS for you first time, run the command below. This command only needs to be run once per user account.
+
+```sh
+git lfs install
+```
+
+Make sure Hugo is in your PATH.
+
+```sh
+hugo version
+```
+
+Then clone the repository.
+
+```sh
+git clone git@github.com:3b1b/3Blue1Brown.com.git
+```
+
+Navigate into the directory and serve the local site.
+
+```sh
+hugo serve
+```
+
+Common flags to use while developing are shown below.
+
+```sh
+hugo serve --buildFuture --buildDrafts --buildExpired
+```
+
+For example, these flags generate the testbed lesson located here: http://localhost:1313/lessons/testbed-lesson/ to be viewed. More flags for Hugo can be found [here](https://gohugo.io/getting-started/usage/).

--- a/content/lessons/_index.md
+++ b/content/lessons/_index.md
@@ -1,3 +1,13 @@
+---
+# https://gohugo.io/content-management/build-options/
+cascade:
+  _build:
+    # This option is set to false to prevent source assets from being published to the linode 
+    # bucket. Resources are still published "on demand" when their .RelPermalink or .Permalink is 
+    # used in a template.
+    publishResources: false
+---
+
 ### Lessons
 
 {{< lesson-gallery show="topics" >}}


### PR DESCRIPTION
- added getting started steps to README.md
- added cascading build option to lesson content type `content/lessons/_index.md`

@vincerubinetti please take a look at the build option. Its motivation is to prevent large resources from being synced to the bucket when they are used **only** as a source for compressed/processed versions of the resource. If the resource's `.RelPermalink` or `.Permalink` attribute is used in a template, it will still be included.

For example, say there is a large source image that gets processed in the build step, but is unused in the build directory.

```
example-lesson/
├── figure.png # large source image  5MB
└── index.md
```

After the build step, the processed images would be present, but the source image would not be and so it won't be synced to the bucket.

```
example-lesson/
├── figure@2x.png
├── figure@1x.png
└── index.md
```

There are other ways to ignore unused source files, but this felt like a good way to do it.