### PR TITLE
Fix math escape

### DIFF
--- a/components/Markdownify/index.js
+++ b/components/Markdownify/index.js
@@ -9,9 +9,6 @@ import rehypeKatex from "rehype-katex";
 
 const Markdownify = ({ children }) => {
   if (typeof children === "string") {
-    // hack to convert string character escape sequences back into their 
-    // original raw strings, e.g. a tab gets converted to a literal "\t"
-    children = JSON.stringify(children).slice(1,-1)
     return (
       <ReactMarkdown remarkPlugins={[remarkMath]} rehypePlugins={[rehypeKatex]}>
         {children}

--- a/components/Question/index.js
+++ b/components/Question/index.js
@@ -5,7 +5,17 @@ import Markdownify from "../Markdownify";
 import { shakeElement } from "../../util/animation";
 import styles from "./index.module.scss";
 
-const Question = ({ question, choices, answer, explanation }) => {
+const Question = ({
+  question,
+  choice1,
+  choice2,
+  choice3,
+  choice4,
+  choice5,
+  choice6,
+  answer,
+  explanation,
+}) => {
   const [selected, setSelected] = useState(0);
   const [state, setState] = useState("unanswered");
   const resultRef = useRef();
@@ -15,12 +25,17 @@ const Question = ({ question, choices, answer, explanation }) => {
 
   // check answer
   const submit = () => {
+    console.log(selected, answer);
     if (selected === answer) setState("correct");
     else {
       setState("incorrect");
       shakeElement(resultRef?.current?.querySelector("button"));
     }
   };
+
+  const choices = [choice1, choice2, choice3, choice4, choice5, choice6].filter(
+    (choice) => choice
+  );
 
   // reset question
   const reset = () => setState("unanswered");

--- a/public/content/lessons/2017/256-bit-security/index.mdx
+++ b/public/content/lessons/2017/256-bit-security/index.mdx
@@ -25,8 +25,11 @@ A core theme of cryptography is to find tasks which are easy in one direction bu
 
 <Question
   question="How many times, on average, do you need to roll a six-sided die until you get a particular number, say a $1$?"
-  choices={["$3$", "$6$", "$9$", "$12$"]}
-  correct={2}
+  choice1="$3$"
+  choice2="$6$"
+  choice3="$9$"
+  choice4="$12$"
+  answer={2}
   explanation="Hopefully this answer is somewhat intuitive, but it actually takes a little work to show why it's true. The probability that your first roll is a $1$ is $\frac{1}{6}$. The probability that your first roll is not a $1$, but the second one is, is $\frac{5}{6} \cdot \frac{1}{6}$. In general, the probability that the first time you see a $1$ is on the $k^{th}$ roll is $\left(\frac{5}{6}\right)^{k-1}\frac{1}{6}$. So the expected number of rolls it will take to see a $1$ for the first time is $$1 \cdot \frac{1}{6}  + 2 \cdot \left(\frac{5}{6}\right) \frac{1}{6} + 3 \cdot \left(\frac{5}{6}\right)^2 \frac{1}{6}  + \cdots= \frac{1}{6}\left(1 + 2 \cdot \frac{5}{6} + 3 \cdot \left(\frac{5}{6}\right)^2 + \cdots \right) $$ Forgive me for distracting from the main point of the article here, but the trick for evaluating something like this is too delightful not to show. Think about how to sum a geometric series: $$1 + x + x^2 + x^3 + \cdots = \frac{1}{1 - x}$$ Now take the derivative of both sides $$1 + 2x + 3x^2 + 4x^3 + \cdots = \frac{1}{(1 - x)^2}$$ Plugging in $x = \frac{5}{6}$, this lets you evaluate the sum above to get $6$. Pretty neat, isn't it?"
 />
 
@@ -70,9 +73,12 @@ There are about 7.9 billion people on Earth, so imagine giving a little over hal
 
 <Question
   question="If you were the president of this KiloGoogle filled Earth, how many guesses could you order to be checked per second?"
-  choices={["$2^{32}$", "$2^{64}$", "$2^{96}$", "$2^{128}$"]}
-  correct={3}
-  explanation="There are $2^{32}$ citizens, each with their personal KiloGoogle that contains $2^{32}$ GPU-packed servers which can each run $2^{32}$ hashes per second. $2^{32}\times 2^{32}\times 2^{32}=2^{96}$."
+  choice1="$2^{32}$"
+  choice2="$2^{64}$"
+  choice3="$2^{96}$"
+  choice4="$2^{128}$"
+  answer={3}
+  explanation="There are $2^{32}$ citizens, each with their personal KiloGoogle that contains $2^{32}$ GPU-packed servers which can each run $2^{32}$ hashes per second. $2^{32} \times 2^{32} \times 2^{32}=2^{96}$."
 />
 
 #### 4 Billion Earths
@@ -111,14 +117,12 @@ So even if you were to have your GPU-packed KiloGoogle-per-person multi-planetar
 
 <Question
   question="If you had your very own KiloGoogle, how many years would it take you to match a GigaGalactic Super Computer with its success rate of 1 in 4 billion?"
-  choices={[
-    "$4\times 10^{40}$",
-    "$5\times 10^{50}$",
-    "$6\times 10^{60}$",
-    "$7\times 10^{70}$",
-  ]}
-  correct={1}
-  explanation="A GigaGalactic Super Computer takes 507 billion ($5.07\times 10^{11}$) years to get a success rate of 1 in 4 billion. Since a GGSC is $2^{96}$ times more powerful than a KiloGoogle, a KiloGoogle will reach a success rate of 1 in 4 billion in $5.07\times 10^{11}\times 2^{96}\approx 4\times 10^{40}$ years. Slightly longer than waiting for cookies to cool from the oven (both seem like forever though)!"
+  choice1="$4 \times 10^{40}$"
+  choice2="$5 \times 10^{50}$"
+  choice3="$6 \times 10^{60}$"
+  choice4="$7 \times 10^{70}$"
+  answer={1}
+  explanation="A GigaGalactic Super Computer takes 507 billion ($5.07 \times 10^{11}$) years to get a success rate of 1 in 4 billion. Since a GGSC is $2^{96}$ times more powerful than a KiloGoogle, a KiloGoogle will reach a success rate of 1 in 4 billion in $5.07 \times 10^{11} \times 2^{96}\approx 4 \times 10^{40}$ years. Slightly longer than waiting for cookies to cool from the oven (both seem like forever though)!"
 />
 
 </Section><Section>

--- a/public/content/lessons/testbed-lesson.mdx
+++ b/public/content/lessons/testbed-lesson.mdx
@@ -120,12 +120,10 @@ Why did the chicken cross the Mobius strip? <Spoiler>To get to the same side.</S
 
 <Question
   question="Why did the chicken cross the road?"
-  choices={[
-    "To get to the other side",
-    "For a bit of $f(x) = e^{i pi} + sin(x)$ and some haggis",
-    "Cannot be determined",
-    "A superposition of all the answers above",
-  ]}
+  choice1="To get to the other side"
+  choice2="For a bit of $f(x) = e^{i pi} + sin(x)$ and some haggis"
+  choice3="Cannot be determined"
+  choice4="A superposition of all the answers above"
   answer={4}
   explanation="Superposition is pretty neat :)"
 />


### PR DESCRIPTION
A few people ran into issues with math characters being incorrectly escaped. For example, the `\t` in `\times` was being converted to a tab character.

Experimenting more, I noticed that sometimes you have to write `\\times` and other times you have to write just `\times`. The problem is, React/JSX/MDX apparently parses `param="$4 \times 10^{40}$"` like a [raw string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/raw), without escaping any characters like `\n`, `\t`, etc., but parses `param={"$4 \times 10^{40}$"}` normally (as expected in javascript), escaping the characters.

Therefore, I've changed the `Question` component to once again take `choice1`, `choice2`, etc as inputs rather than an array, and all future components should be made to accept plain string arguments where math is needed. This will allow authors to use the regular single `\` latex syntax they're used to.