### PR TITLE
Sync Action Update

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-pages/lessons/**/*.mp4 filter=lfs diff=lfs merge=lfs -text
-pages/lessons/**/*.png filter=lfs diff=lfs merge=lfs -text
-pages/lessons/**/*.mov filter=lfs diff=lfs merge=lfs -text
+public/content/**/*.mp4 filter=lfs diff=lfs merge=lfs -text
+public/content/**/*.png filter=lfs diff=lfs merge=lfs -text
+public/content/**/*.mov filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/sync-assets.yaml
+++ b/.github/workflows/sync-assets.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - sync-action-update
 
 jobs:
   deploy:
@@ -19,22 +20,6 @@ jobs:
 
       - name: Checkout LFS objects
         run: git lfs checkout
-
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
-        with:
-          hugo-version: '0.83.1'
-          extended: true
-
-      - name: Build
-        run: hugo --environment production
-
-      # - name: Deploy Site
-      #   uses: peaceiris/actions-gh-pages@v3
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     exclude_assets: 'lessons/**/*.jpg,lessons/**/*.mp4,lessons/**/*.png'
-      #     publish_dir: ./public
 
       - name: Sync bucket
         uses: ./.github/actions/sync

--- a/.github/workflows/sync-assets.yaml
+++ b/.github/workflows/sync-assets.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - sync-action-update
 
 jobs:
   deploy:

--- a/components/Figure/index.js
+++ b/components/Figure/index.js
@@ -9,8 +9,11 @@ import styles from "./index.module.scss";
 const transformSrc = (src, dir) => {
   if (src.startsWith("http")) return src;
   else {
-    if (process.env.mode === "production") return bucket + src;
-    else return dir + src;
+    if (process.env.mode === "production") {
+      return bucket + src;
+    } else {
+      return dir + src;
+    }
   }
 };
 

--- a/components/Figure/index.js
+++ b/components/Figure/index.js
@@ -5,15 +5,14 @@ import { bucket } from "../../data/site.yaml";
 import { PageContext } from "../../pages/_app";
 import styles from "./index.module.scss";
 
-// change provided srcs to external bucket location for production
+// change provided srcs (png & mp4) to external bucket location for production.
 const transformSrc = (src, dir) => {
-  if (src.startsWith("http")) return src;
-  else {
-    if (process.env.mode === "production") {
-      return bucket + dir + src;
-    } else {
-      return dir + src;
-    }
+  if (src.startsWith("http")) {
+    return src;
+  } else if (process.env.mode === "production" && !src.endsWith("svg") ) {
+    return bucket + dir + src;
+  } else {
+    return dir + src;
   }
 };
 

--- a/components/Figure/index.js
+++ b/components/Figure/index.js
@@ -10,7 +10,7 @@ const transformSrc = (src, dir) => {
   if (src.startsWith("http")) return src;
   else {
     if (process.env.mode === "production") {
-      return bucket + src;
+      return bucket + dir + src;
     } else {
       return dir + src;
     }


### PR DESCRIPTION
Opening this pull request to preview and test the sync action.

Changes:

- Changed `.gitattributes` rules to reference `public/content/**/...` instead of `pages/lessons/**/...` after noticing lesson media files not managed by LFS.
- Added `dir` when building the bucket URL
- Excluded SVG file types from be prepended with bucket URL since they are served from Netlify

@3b1b I tested the production environment locally and things looked fine. Next step would be to merge into main and check the live site. As long as the `process.env.mode` is set to `production` it should work as intented.