### PR TITLE
Remove fade effect from lessons list

### DIFF
--- a/components/Fade/index.js
+++ b/components/Fade/index.js
@@ -1,3 +1,15 @@
+/*
+
+Note: As of June 23, 2021, this component is not being used, so elements
+with data-fade will not fade in as expected. To re-enable this behavior,
+import the component and use it in NormalLayout.js.
+
+If you are living far in the future and nobody is using this component,
+consider deleting it. (I'm preserving it for now in case we want it
+again in the near future.)
+
+*/
+
 import { useEffect } from "react";
 
 // options

--- a/components/LessonCard/index.js
+++ b/components/LessonCard/index.js
@@ -41,7 +41,7 @@ const LessonCard = ({
       data-active={active || false}
       data-mini={mini || false}
       data-reverse={reverse || false}
-      data-fade
+      // data-fade
     >
       {icon && <i className={icon}></i>}
 
@@ -53,7 +53,9 @@ const LessonCard = ({
 
       <div className={styles.text}>
         <span>{title && <span className={styles.title}>{title}</span>}</span>
-        {description && !mini && <span className={styles.description}>{description}</span>}
+        {description && !mini && (
+          <span className={styles.description}>{description}</span>
+        )}
         {(chapter || !empty || date) && !mini && (
           <span>
             {chapter && (

--- a/components/LessonGallery/index.js
+++ b/components/LessonGallery/index.js
@@ -88,7 +88,7 @@ const TopicCard = ({ topic, opened, onClick }) => {
         className={styles.topic_card}
         onClick={onClick}
         data-open={opened}
-        data-fade
+        // data-fade
       >
         <img
           className={styles.image}

--- a/layouts/NormalLayout.js
+++ b/layouts/NormalLayout.js
@@ -5,7 +5,7 @@ import Footer from "../components/Footer";
 import PageContent from "../components/PageContent";
 import Anchors from "../components/Anchors";
 import Glow from "../components/Glow";
-import Fade from "../components/Fade";
+// import Fade from "../components/Fade";
 
 // default, normal layout
 const Normal = ({ children }) => (
@@ -17,7 +17,7 @@ const Normal = ({ children }) => (
     {/* singleton components */}
     <Anchors />
     <Glow />
-    <Fade />
+    {/* <Fade /> */}
     {/* main content of page */}
     <Main>
       {!children && <PageContent />}


### PR DESCRIPTION
Closes #115. Grant and I agreed that the fade made the site feel slow, but before removing it for sure I would like some feedback from others just to double check that this is a good change.

Website change review checklist:
- [x] I have requested a review from the appropriate persons
- [x] I have checked that my changes work in the preview
- [x] I have checked that the rest of the site is still functioning in the preview
- [x] I have checked that my content/code is consistent with existing content/code
- [x] I have used components in the places and ways they are intended (see the readme)
- [x] I have formatted all of my code with Prettier

<!-- List what this pull request adds/changes/removes/fixes. Paste into message box when you squash merge. -->

This pull request:
- Removes the fade effect from the lessons list