### PR TITLE
Add video icon, change text icon to newspaper

### DIFF
--- a/components/LessonCard/index.js
+++ b/components/LessonCard/index.js
@@ -56,18 +56,25 @@ const LessonCard = ({
         {description && !mini && (
           <span className={styles.description}>{description}</span>
         )}
-        {(chapter || !empty || date) && !mini && (
+        {(chapter !== undefined || !!video || !empty || date) && !mini && (
           <span>
-            {chapter && (
+            {chapter !== undefined && (
               <Chip
                 text={(mini ? "Ch" : "Chapter") + " " + chapter}
                 mini={mini}
                 tooltip={`In topic "${topic}"`}
               />
             )}
+            {!!video && (
+              <Chip
+                icon="fab fa-youtube"
+                mini={mini}
+                tooltip="This lesson has a video version"
+              />
+            )}
             {!empty && (
               <Chip
-                icon="fas fa-pencil-alt"
+                icon="far fa-newspaper"
                 mini={mini}
                 tooltip="This lesson has a text version"
               />


### PR DESCRIPTION
Website change review checklist:

- [ ] I have requested a review from the appropriate persons
- [x] I have checked that my changes work in the preview
- [x] I have checked that the rest of the site is still functioning in the preview
- [x] I have checked that my content/code is consistent with existing content/code
- [x] I have used components in the places and ways they are intended (see the readme)
- [x] I have formatted all of my code with Prettier

This pull request:
- Adds a "video" icon to all lessons with an associated video (which is currently all of them)
- Change from a pencil icon to a newspaper for lessons with a text version available
- Closes #120