### PR TITLE
Make lessons narrower, everything else wider

### DIFF
--- a/components/Clickable/index.module.scss
+++ b/components/Clickable/index.module.scss
@@ -16,7 +16,7 @@
   background: $gray-200;
   color: $black;
 
-  &:enabled:hover {
+  &:not(:disabled):hover {
     background: $light-blue-100;
   }
 

--- a/components/ContactForms/index.module.scss
+++ b/components/ContactForms/index.module.scss
@@ -1,5 +1,3 @@
-$width: 600px;
-
 .receivedFormThanks {
   background: $green-200;
   padding: 16px 24px;
@@ -8,7 +6,6 @@ $width: 600px;
 
 .form {
   text-align: left;
-  max-width: $width;
   margin: 0 auto;
 
   button {
@@ -64,7 +61,7 @@ textarea.input {
   margin-bottom: 16px;
 }
 
-@media screen and (min-width: $width) {
+@media screen and (min-width: $page-narrow) {
   .inputRow {
     // Browsers that don't support grid will still gracefully fall back to a single-column layout
     display: grid;

--- a/components/Figure/index.js
+++ b/components/Figure/index.js
@@ -4,6 +4,7 @@ import Clickable from "../Clickable";
 import { bucket } from "../../data/site.yaml";
 import { PageContext } from "../../pages/_app";
 import styles from "./index.module.scss";
+import { useSectionWidth } from "../Section";
 
 // change provided srcs (png & mp4) to external bucket location for production.
 const transformSrc = (src, dir) => {
@@ -22,8 +23,8 @@ const transformSrc = (src, dir) => {
 
 // return dimensions to display image/video at, based on intrinsic dimensions
 // https://www.desmos.com/calculator/baf0zz662q
-const autoSize = ({ width, height }) => {
-  const page = 960; // page column width. keep synced with $page in sass
+const autoSize = ({ width, height }, sectionWidth) => {
+  const page = sectionWidth === "narrow" ? 780 : 1100; // page column width. keep synced with $page in sass
   const ratio = 4; // width to height ratio at which image width matches page column width
 
   return {
@@ -59,12 +60,14 @@ const Figure = ({
   // page front matter
   const { dir } = useContext(PageContext);
 
+  const sectionWidth = useSectionWidth();
+
   // determine frame dimensions
   let frame = {};
   if (manualWidth) frame = { width: manualWidth };
   else if (manualHeight) frame = { maxHeight: manualHeight };
-  else if (show === "image") frame = autoSize(image);
-  else if (show === "video") frame = autoSize(video);
+  else if (show === "image") frame = autoSize(image, sectionWidth);
+  else if (show === "video") frame = autoSize(video, sectionWidth);
 
   // determine controls dimensions
   let controls = { width: frame.width };

--- a/components/PageContent/index.js
+++ b/components/PageContent/index.js
@@ -11,7 +11,9 @@ const PageContent = () => {
   // if markdown file doesn't start with section, wrap with section
   // allows authors to not include any sections and get their mdx auto-wrapped
   let Wrapper = Fragment;
-  if (!content.trim().startsWith("<Section")) Wrapper = Section;
+  if (!content.trim().startsWith("<Section")) {
+    Wrapper = ({ children }) => <Section width="narrow">{children}</Section>;
+  }
 
   if (!source) return null;
   return (

--- a/components/PiCreature/index.js
+++ b/components/PiCreature/index.js
@@ -3,6 +3,7 @@ import Markdownify from "../Markdownify";
 import styles from "./index.module.scss";
 import SpeechBubble from "../../public/images/pi-creatures/bubble-speech.svg";
 import ThoughtBubble from "../../public/images/pi-creatures/bubble-thought.svg";
+import { useSectionWidth } from "../Section";
 
 // pi creature/character, with "smart" positioning, and speech/thought bubble
 const PiCreature = ({
@@ -20,6 +21,8 @@ const PiCreature = ({
     else Bubble = SpeechBubble;
   }
 
+  const sectionWidth = useSectionWidth();
+
   return (
     <div
       className={styles.pi_creature}
@@ -27,6 +30,7 @@ const PiCreature = ({
       data-placement={placement || "auto"}
       data-design={design}
       data-text={text ? true : false}
+      data-sectionWidth={sectionWidth}
     >
       <div className={styles.frame}>
         <img src={`/images/pi-creatures/${emotion}.svg`} />

--- a/components/PiCreature/index.module.scss
+++ b/components/PiCreature/index.module.scss
@@ -1,5 +1,3 @@
-$page: $page + 600px;
-
 .pi_creature {
   &[data-text="false"] {
     --size: 150px;
@@ -116,28 +114,40 @@ $page: $page + 600px;
   line-height: $spacing - 0.4;
 }
 
-.pi_creature[data-placement="side"] {
-  position: absolute;
+@mixin pi-position($sectionWidth) {
+  $cutoffWidth: $sectionWidth + 600px;
 
-  @media (max-width: $page) {
-    display: none;
-  }
-
-  .frame {
-    transform: translateY(-100%);
-  }
-}
-
-.pi_creature[data-placement="auto"] {
-  @media (min-width: $page) {
+  &[data-placement="side"] {
     position: absolute;
+
+    @media (max-width: $cutoffWidth) {
+      display: none;
+    }
 
     .frame {
       transform: translateY(-100%);
     }
   }
 
-  @media (max-width: $page) {
-    position: static;
+  &[data-placement="auto"] {
+    @media (min-width: $cutoffWidth) {
+      position: absolute;
+
+      .frame {
+        transform: translateY(-100%);
+      }
+    }
+
+    @media (max-width: $cutoffWidth) {
+      position: static;
+    }
   }
+}
+
+.pi_creature[data-sectionWidth="normal"] {
+  @include pi-position($page);
+}
+
+.pi_creature[data-sectionWidth="narrow"] {
+  @include pi-position($page-narrow);
 }

--- a/components/Portrait/index.js
+++ b/components/Portrait/index.js
@@ -1,8 +1,11 @@
+import { useSectionWidth } from "../Section";
 import styles from "./index.module.scss";
 
 // circular image that floats to left/right of text content, useful for pictures
 // of people
 const Portrait = ({ image, size = "180px", flip = false }) => {
+  const sectionWidth = useSectionWidth();
+
   // if no image, don't render
   if (!image) return null;
 
@@ -11,6 +14,7 @@ const Portrait = ({ image, size = "180px", flip = false }) => {
       className={styles.portrait}
       style={{ width: size, height: size }}
       data-flip={flip}
+      data-sectionWidth={sectionWidth}
     >
       <img src={image} />
     </div>

--- a/components/Portrait/index.module.scss
+++ b/components/Portrait/index.module.scss
@@ -12,16 +12,25 @@
 }
 
 @media (min-width: $page) {
-  .portrait[data-flip="false"] {
+  .portrait[data-sectionWidth="normal"][data-flip="false"] {
     margin-right: 40px;
     float: left;
   }
 
-  .portrait[data-flip="true"] {
+  .portrait[data-sectionWidth="normal"][data-flip="true"] {
     margin-left: 40px;
     float: right;
   }
 }
 
-@media (max-width: $page) {
+@media (min-width: $page-narrow) {
+  .portrait[data-sectionWidth="narrow"][data-flip="false"] {
+    margin-right: 40px;
+    float: left;
+  }
+
+  .portrait[data-sectionWidth="narrow"][data-flip="true"] {
+    margin-left: 40px;
+    float: right;
+  }
 }

--- a/components/Section/index.js
+++ b/components/Section/index.js
@@ -1,3 +1,4 @@
+import { createContext, useContext } from "react";
 import styles from "./index.module.scss";
 
 // section wrapper component that spans entire width of screen and colors
@@ -5,10 +6,19 @@ import styles from "./index.module.scss";
 
 // make sure markdown starts and ends with this component, or doesn't use it at
 // all. see PageContent component.
-const Section = ({ children, dark }) => (
-  <section className={styles.section} data-dark={dark}>
-    <div className={styles.wrapper}>{children}</div>
-  </section>
+const SectionContext = createContext({ width: "normal" });
+
+const Section = ({ children, dark, width = "normal" }) => (
+  <SectionContext.Provider value={{ width }}>
+    <section className={styles.section} data-dark={dark} data-width={width}>
+      <div className={styles.wrapper}>{children}</div>
+    </section>
+  </SectionContext.Provider>
 );
 
 export default Section;
+
+export function useSectionWidth() {
+  const { width } = useContext(SectionContext);
+  return width;
+}

--- a/components/Section/index.module.scss
+++ b/components/Section/index.module.scss
@@ -8,7 +8,7 @@ $phone: 500px;
   &:nth-child(odd) {
     background: $gray-50;
   }
-  
+
   &:nth-child(even) {
     background: $white;
   }
@@ -30,4 +30,8 @@ $phone: 500px;
   @media (max-width: $phone) {
     padding: 20px;
   }
+}
+
+.section[data-width="narrow"] > .wrapper {
+  max-width: $page-narrow;
 }

--- a/public/content/contact.mdx
+++ b/public/content/contact.mdx
@@ -1,4 +1,4 @@
-<Section>
+<Section width="narrow">
 
 <!-- This message only appears after submitting a contact form -->
 
@@ -8,12 +8,9 @@
 
 <Accordion title="What do you use to animate your videos?">
 
-<Figure 
-  image="../images/contact/manim_wide.png"
-  width="500px"
-/>
+<Figure image="../images/contact/manim_wide.png" width="500px" />
 
-Almost all animations are made using a custom open-source python library named [Manim](https://github.com/3b1b/manim).  I started the project concurrently with starting the channel, intending for it to be more of a scrappy playground of code for my own use cases than an explicitly outward-facing or professionally maintained tool.
+Almost all animations are made using a custom open-source python library named [Manim](https://github.com/3b1b/manim). I started the project concurrently with starting the channel, intending for it to be more of a scrappy playground of code for my own use cases than an explicitly outward-facing or professionally maintained tool.
 
 Since its inception, a [community](https://www.manim.community/) got together and created an [alternate fork](https://github.com/ManimCommunity/manim/) which is aimed at being more stable, better documented, and better tested. Anyone looking to get started with manim should probably begin with the community version.
 
@@ -21,11 +18,11 @@ The original version, used for 3b1b videos, is perhaps best viewed as a testing 
 
 There many [other](https://www.youtube.com/vcubingx) [excellent](https://www.youtube.com/channel/UCGYouJhklRHc_EfKwpIrTyw) [channels](https://www.youtube.com/reducible) that have made use of it for their own expository videos.
 
-If you want to make your own animated math videos, I would encourage you to also take a look at the full landscape of tools available.  For simple graphing, you can’t beat Desmos.  Geogebra is also incredibly extensive, and if you use a mac I’d recommend looking at Grapher.  For plotting, matplotlib is of course extensive, and Mathematica is also a bottomless pit of functionality.  The main difference between manim and other math-visualizing tools is that it’s structured to build potentially-long scenes for videos and to hopefully look smoother and prettier than, say, matplotlib.
+If you want to make your own animated math videos, I would encourage you to also take a look at the full landscape of tools available. For simple graphing, you can’t beat Desmos. Geogebra is also incredibly extensive, and if you use a mac I’d recommend looking at Grapher. For plotting, matplotlib is of course extensive, and Mathematica is also a bottomless pit of functionality. The main difference between manim and other math-visualizing tools is that it’s structured to build potentially-long scenes for videos and to hopefully look smoother and prettier than, say, matplotlib.
 
-Keep in mind, plenty of professional animation tools like Blender and After Effects can be made programmatic too.  Also, be sure to ask yourself if what you’re doing actually benefits from being programmatic.  If all you’re looking to do is simple moving/fading animations, using something simple like Keynote or PowerPoint might take you farther than you’d expect.
+Keep in mind, plenty of professional animation tools like Blender and After Effects can be made programmatic too. Also, be sure to ask yourself if what you’re doing actually benefits from being programmatic. If all you’re looking to do is simple moving/fading animations, using something simple like Keynote or PowerPoint might take you farther than you’d expect.
 
-It’s wonderful to see others using manim, especially if it helps them explain math in ways that otherwise would have been hard, but often I see folks using it mainly to animate simple movements or to write and manipulate Latex expressions.  In those cases, and I fully acknowledge the hypocrisy here, I can’t help but speculate that another tool might have made the job easier.  I also get worried when I hear people ask things like “how do I sync up narration into manim”.  This is just a tool for spitting out the individual clips to be edited together later, you should certainly use traditional video-editing software for as much as you can!
+It’s wonderful to see others using manim, especially if it helps them explain math in ways that otherwise would have been hard, but often I see folks using it mainly to animate simple movements or to write and manipulate Latex expressions. In those cases, and I fully acknowledge the hypocrisy here, I can’t help but speculate that another tool might have made the job easier. I also get worried when I hear people ask things like “how do I sync up narration into manim”. This is just a tool for spitting out the individual clips to be edited together later, you should certainly use traditional video-editing software for as much as you can!
 
 Where programatic animations works best is when you have a situation where the code directly reflects the math you’re trying to explain, or where iteration, abstraction, and conditionals make a set of illustrations possible which otherwise would have taken much too long to do manually.
 
@@ -35,10 +32,10 @@ Where programatic animations works best is when you have a situation where the c
 
 <Center>
   <Clickable
-      link="https://www.reddit.com/r/3Blue1Brown/comments/mllj2s/topic_requests/"
-      icon="fab fa-reddit"
-      text="Topic suggestions go here"
-      design="rounded"
+    link="https://www.reddit.com/r/3Blue1Brown/comments/mllj2s/topic_requests/"
+    icon="fab fa-reddit"
+    text="Topic suggestions go here"
+    design="rounded"
   />
 </Center>
 
@@ -58,7 +55,7 @@ In the same way that many channels simply share their name with the author, a yo
 
 <Accordion title="What's the music playing in your videos?">
 
-Most music has been by written by Vince Rubinetti, which you can download on [Bandcamp](https://vincerubinetti.bandcamp.com/album/the-music-of-3blue1brown) and stream on [Spotify](https://open.spotify.com/album/1dVyjwS8FBqXhRunaG5W5u), [Apple Music](https://itunes.apple.com/us/album/the-music-of-3blue1brown/1448166136), and [Google Play](https://play.google.com/music/listen?u=0#/wst/album/Bk27zbtbjerlpajx3kplrvy3goe).  The piano song throughout the Linear Algebra and Calculus series, which Vince listed as “Grant’s etude” and “Grant’s Opus” on the album, are little snippets that I wrote.
+Most music has been by written by Vince Rubinetti, which you can download on [Bandcamp](https://vincerubinetti.bandcamp.com/album/the-music-of-3blue1brown) and stream on [Spotify](https://open.spotify.com/album/1dVyjwS8FBqXhRunaG5W5u), [Apple Music](https://itunes.apple.com/us/album/the-music-of-3blue1brown/1448166136), and [Google Play](https://play.google.com/music/listen?u=0#/wst/album/Bk27zbtbjerlpajx3kplrvy3goe). The piano song throughout the Linear Algebra and Calculus series, which Vince listed as “Grant’s etude” and “Grant’s Opus” on the album, are little snippets that I wrote.
 
 If you are interested in using this music, see [this form](https://vincerubinetti.github.io/using-the-music-of-3blue1brown/) from Vince’s site.
 
@@ -70,39 +67,39 @@ Recently, YouTube stopped supporting the [built-in tools](https://support.google
 
 Since YouTube is not available in China, there is a small team of volunteers that make them available on [Bilibili](https://space.bilibili.com/88461692/#/) with Chinese translations. You can find the means of contacting the team on that page if you want to help out.
 
-Perhaps you're wondering about dubbing content. Again, I'm grateful for any contributions, but you should know it takes *significantly* more time, which many people underestimate.
+Perhaps you're wondering about dubbing content. Again, I'm grateful for any contributions, but you should know it takes _significantly_ more time, which many people underestimate.
 
 Nevertheless, if you have a good mic, some video editing savvy, and you are willing to put in that time, we can set up an alternate 3b1b channel where they can be uploaded in an official capacity. Just send a message through the link below once you have created one. You can of course credit yourself on screen and in the description as the translator, and we can point to your own website/channel from there once it's been uploaded if you'd like.
 
 Current translated channels.
 
--   [Chinese](https://space.bilibili.com/88461692/#/) (as mentioned above, on Bilibili)
+- [Chinese](https://space.bilibili.com/88461692/#/) (as mentioned above, on Bilibili)
 
--   [Spanish](https://www.youtube.com/channel/UCQbsk1JQNaskUlfdoyiWJDg)
+- [Spanish](https://www.youtube.com/channel/UCQbsk1JQNaskUlfdoyiWJDg)
 
--   [Russian](https://www.youtube.com/channel/UC6hAYNOWMmuqOBvFOuAFKwA)
+- [Russian](https://www.youtube.com/channel/UC6hAYNOWMmuqOBvFOuAFKwA)
 
--   [Russian as translated by Scieberia](https://www.youtube.com/channel/UCCbgOIWdmYncvYMbl3LjvBQ)
+- [Russian as translated by Scieberia](https://www.youtube.com/channel/UCCbgOIWdmYncvYMbl3LjvBQ)
 
--   [Turkish](https://www.youtube.com/channel/UCx64ou5qw0Q9LLkwE8xSNEg)
+- [Turkish](https://www.youtube.com/channel/UCx64ou5qw0Q9LLkwE8xSNEg)
 
--   [German](https://www.youtube.com/channel/UC35HbRQCcdmhMgjPN_oOQyg)
+- [German](https://www.youtube.com/channel/UC35HbRQCcdmhMgjPN_oOQyg)
 
--   [Czech](https://www.youtube.com/channel/UCIhWS2rX78OXidZ87QLkkxA)
+- [Czech](https://www.youtube.com/channel/UCIhWS2rX78OXidZ87QLkkxA)
 
--   [Italian](https://www.youtube.com/channel/UCrzQ4FI3T9l3YbDsb_9GXng/)
+- [Italian](https://www.youtube.com/channel/UCrzQ4FI3T9l3YbDsb_9GXng/)
 
--   [Portuguese](https://www.youtube.com/channel/UCT1gsOeAb4EGUHl54TNiPUg/)
+- [Portuguese](https://www.youtube.com/channel/UCT1gsOeAb4EGUHl54TNiPUg/)
 
--   [Finnish](https://www.youtube.com/channel/UCumsfZAhY3rP1FpbuhQYV3A/)
+- [Finnish](https://www.youtube.com/channel/UCumsfZAhY3rP1FpbuhQYV3A/)
 
--   [Korean](https://www.youtube.com/channel/UCJK07Uk2KY9r78ksPoXg-3g)
+- [Korean](https://www.youtube.com/channel/UCJK07Uk2KY9r78ksPoXg-3g)
 
--   [Japanese](https://www.youtube.com/channel/UCBevyiJ2ierZY-0yZhfLrmQ/)
+- [Japanese](https://www.youtube.com/channel/UCBevyiJ2ierZY-0yZhfLrmQ/)
 
--   [Hindi](https://www.youtube.com/channel/UCU1gppH-Msk5RgXIsJ91SJw)
+- [Hindi](https://www.youtube.com/channel/UCU1gppH-Msk5RgXIsJ91SJw)
 
-**You are not allowed to re-upload the content on your own channel, and such re-uploaded content will be taken down as a copyright violation**.  I know that might seem harsh, and that many re-uploaded dubbed videos are done in good faith trying to spread math around the world.  However, there need to be consistent principles around how the lessons are put out under the channel name.  To take one potential problem, there is otherwise no mechanism for preventing the insertion of unwanted promotional or sponsored additions, or other sorts of edits that misrepresent the original intent of a video.
+**You are not allowed to re-upload the content on your own channel, and such re-uploaded content will be taken down as a copyright violation**. I know that might seem harsh, and that many re-uploaded dubbed videos are done in good faith trying to spread math around the world. However, there need to be consistent principles around how the lessons are put out under the channel name. To take one potential problem, there is otherwise no mechanism for preventing the insertion of unwanted promotional or sponsored additions, or other sorts of edits that misrepresent the original intent of a video.
 
 </Accordion>
 
@@ -110,9 +107,9 @@ Current translated channels.
 
 <Center>
   <Clickable
-      link="https://www.3blue1brown.com/recommendations"
-      text="See this blog post"
-      design="rounded"
+    link="https://www.3blue1brown.com/recommendations"
+    text="See this blog post"
+    design="rounded"
   />
 </Center>
 
@@ -135,7 +132,7 @@ Unfortunately, no. There are two important things to note here:
 
 <Accordion title="Will you speak at my event?">
 
-Maybe!  Feel free to share the details through the contact form below.  Just know my main focus will always be the videos, so talks are typically kept to a minimum.
+Maybe! Feel free to share the details through the contact form below. Just know my main focus will always be the videos, so talks are typically kept to a minimum.
 
 </Accordion>
 
@@ -147,14 +144,14 @@ The channel [no longer does sponsored videos](https://www.patreon.com/posts/goin
 
 <Accordion title="Can I use/license these videos?">
 
-Under the standard YouTube license, you are free to embed the videos in your own site or blog as much as you’d like, as long as it is not behind a paywall.  You may not re-upload them to other platforms without permission.  If you want to use some of the visuals offline in a classroom, or for a talk/presentation, by all means, feel free to do so.  In both cases, attribution is of course appreciated.
+Under the standard YouTube license, you are free to embed the videos in your own site or blog as much as you’d like, as long as it is not behind a paywall. You may not re-upload them to other platforms without permission. If you want to use some of the visuals offline in a classroom, or for a talk/presentation, by all means, feel free to do so. In both cases, attribution is of course appreciated.
 
 If you wish to license the videos to include in a commercial product, feel free to send an inquiry with the contact link below specifying the details.
 
 </Accordion>
 
 </Section>
-<Section>
+<Section width="narrow">
 
 # Contact
 

--- a/public/content/lessons/2017/256-bit-security/index.mdx
+++ b/public/content/lessons/2017/256-bit-security/index.mdx
@@ -9,8 +9,6 @@ credits:
   - Text adaptation by River Way
 ---
 
-<Section>
-
 ## What is 256 bit security?
 
 If a protocol is described as having "$n$-bit security", it means an attacker would have to run some computation $2^n$ times to break the system.
@@ -33,7 +31,6 @@ A core theme of cryptography is to find tasks which are easy in one direction bu
 
 Hopefully this answer is somewhat intuitive, but it actually takes a little work to show why it's true. The probability that you see that $1$ on the very first roll is $\frac{1}{6}$.
 
-
 $$
 P(\#\text{Rolls} = 1) = \frac{1}{6}
 $$
@@ -44,13 +41,13 @@ $$
 P(\#\text{Rolls} = 2) = \frac{5}{6} \cdot \frac{1}{6}
 $$
 
-In general, the probability that the first time you see a $1$ is on the $k^{th}$ roll is 
+In general, the probability that the first time you see a $1$ is on the $k^{th}$ roll is
 
 $$
 P(\#\text{Rolls} = k) = \left(\frac{5}{6}\right)^{k-1} \frac{1}{6}.
 $$
 
-So the expected number of rolls it will take to see a $1$ for the first time is 
+So the expected number of rolls it will take to see a $1$ for the first time is
 
 $$
 1 \cdot \frac{1}{6}  + 2 \cdot \left(\frac{5}{6}\right) \frac{1}{6} + 3 \cdot \left(\frac{5}{6}\right)^2 \frac{1}{6}  + \cdots= \frac{1}{6}\left(1 + 2 \cdot \frac{5}{6} + 3 \cdot \left(\frac{5}{6}\right)^2 + \cdots \right).
@@ -73,8 +70,6 @@ Plugging in $x = \frac{5}{6}$, this lets you evaluate the sum above to get $6$. 
 </Question>
 
 For SHA256, there are not six possible outputs, there are $2^{256}$. So on average it will take $2^{256}$ guesses to find an input with a particular hash[ [2](/lessons/256-bit-security/#footnotes)]. But how difficult is this, exactly? A number like $2^{256}$ is so far removed from anything we ever deal with that it can be hard to appreciate its size. Nevertheless, let’s give it a try.
-
-</Section><Section>
 
 ## Appreciating Large Powers of Two
 
@@ -170,8 +165,6 @@ A GigaGalactic Super Computer takes 507 billion ($5.07 \times 10^{11}$) years to
 
 </Question>
 
-</Section><Section>
-
 ## Modern Bitcoin Hashing
 
 In 2021, all the miners put together make guesses at a rate of about [100 billion billion](https://www.blockchain.com/charts/hash-rate) ($10^{20}\approx 2^{66}$ ) hashes per second. Which is four times more than what was described as a KiloGoogle.
@@ -187,5 +180,3 @@ These are pieces of hardware specifically designed for bitcoin mining and nothin
 [1] Once an attacker breaches a database, they only have the hash of the user's password. Passwords are often not unique, so an attacker can use a rainbow table of precomputed hashes of common passwords. To prevent this, a good server will give each user a randomly generated number, known as a salt and append it to the end of the password before hashing. An even better approach is to generate honeywords, which are fake passwords whose salted hashes are stored in a list mixed with the real salted hashed password. The index of the real password in the list is stored on a separate server. If the index server is the only one breached, no passwords are leaked. If the honey server is the only one breached, the attackers don't know which hash is the real password, preventing a majority of the passwords being leaked. The attackers must breach both the honey and index servers to even be allowed to perform offline password cracking. [↩](#cryptographic-hash-functions)
 
 [2] Other attacks, such as finding a [hash collision](https://en.wikipedia.org/wiki/Birthday_attack) with a birthday attack only requires $2^{128}$ guesses on average. Quantum computers can run [Grover's algorithm](https://en.wikipedia.org/wiki/Grover%27s_algorithm) to invert a hash, but it also requires $2^{128}$ iterations. If you are concerned about quantum computers making your hashing algorithm insecure, simply double the output size to 512 bits which provides the same security as 256 bits does on a classical computer. [↩](#cryptographic-hash-functions)
-
-</Section>

--- a/styles/theme.scss
+++ b/styles/theme.scss
@@ -14,4 +14,5 @@ $fast: 0.2s ease;
 $slow: 0.5s ease;
 
 // page content column width
-$page: 960px;
+$page: 1100px;
+$page-narrow: 780px;


### PR DESCRIPTION
Website change review checklist:
- [x] I have requested a review from the appropriate persons
- [x] I have checked that my changes work in the preview
- [x] I have checked that the rest of the site is still functioning in the preview
- [x] I have checked that my content/code is consistent with existing content/code
- [x] I have used components in the places and ways they are intended (see the readme)
- [x] I have formatted all of my code with Prettier

This pull request:
- Adds a prop to `Section` called `width` that can either be `"normal"` or `"narrow"`
- Uses different `Section` widths in different parts of the site
- Passes the current width down to components which need to know it (`PiCreature` and `Portrait`) for their positioning.
- Closes #112

This PR is a bit spooky because the page width affects *everything*, so there are lots of little corners where things could break. But I've taken quite a bit of time to comb through all the uses of the `$page` width variable, as well as looking through different pages, and I *think* everything is good.
