### PR TITLE
Add inline footnotes

### DIFF
--- a/components/Footnote/index.js
+++ b/components/Footnote/index.js
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { usePopper } from "react-popper";
+import styles from "./index.module.scss";
+
+export default function Footnote({ label, children }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const [referenceElement, setReferenceElement] = useState(null);
+  const [popperElement, setPopperElement] = useState(null);
+  const [arrowElement, setArrowElement] = useState(null);
+
+  const { styles: popperStyles, attributes } = usePopper(
+    referenceElement,
+    popperElement,
+    {
+      placement: "top",
+      modifiers: [
+        // https://github.com/popperjs/popper-core/issues/1138
+        { name: "computeStyles", options: { adaptive: false } },
+        { name: "offset", options: { offset: [0, 10] } },
+        { name: "arrow", options: { element: arrowElement, padding: 10 } },
+      ],
+    }
+  );
+
+  // Close footnote when you click outside (anywhere else on the page)
+  useEffect(() => {
+    const onClick = (event) => {
+      if (popperElement && !popperElement.contains(event.target)) {
+        if (referenceElement && !referenceElement.contains(event.target)) {
+          setIsOpen(false);
+        }
+      }
+    };
+
+    document.addEventListener("click", onClick);
+    return () => {
+      document.removeEventListener("click", onClick);
+    };
+  }, [popperElement, referenceElement]);
+
+  return (
+    <>
+      <button
+        ref={setReferenceElement}
+        className={styles.footnoteLabel}
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+      >
+        {label}
+      </button>
+
+      {isOpen &&
+        createPortal(
+          <div
+            ref={setPopperElement}
+            className={styles.popup}
+            style={popperStyles.popper}
+            {...attributes.popper}
+          >
+            <div className={styles.popupContent}>{children}</div>
+            <div
+              ref={setArrowElement}
+              className={styles.arrow}
+              style={popperStyles.arrow}
+            />
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/components/Footnote/index.module.scss
+++ b/components/Footnote/index.module.scss
@@ -1,0 +1,98 @@
+.footnoteLabel {
+  width: 20px;
+  height: 20px;
+  font-size: 14px;
+  vertical-align: middle;
+
+  position: relative;
+  bottom: 2px;
+  margin: 0 2px;
+
+  border-radius: 9999px;
+  background: $blue-400;
+  color: $white;
+
+  cursor: pointer;
+}
+
+.footnoteLabel:hover {
+  background: $blue-600;
+}
+
+$popupColor: $gray-300;
+
+.popup {
+  position: absolute;
+  z-index: 11;
+  background: $popupColor;
+  width: 90vw;
+  max-width: 400px;
+}
+
+.popupContent {
+  font-size: 15px;
+  color: $gray-800;
+
+  max-height: 40vh;
+  padding: 16px;
+  overflow-y: auto;
+
+  // Make the content appear on top of the arrow element:
+  position: relative;
+  z-index: 1;
+}
+
+.popupContent p {
+  line-height: 1.6;
+}
+
+.popupContent::before,
+.popupContent::after {
+  content: " ";
+  position: fixed;
+  left: 0;
+  right: 0;
+  height: 16px;
+}
+.popupContent::before {
+  top: 0;
+  background: linear-gradient($popupColor, transparent);
+}
+.popupContent::after {
+  bottom: 0;
+  background: linear-gradient(transparent, $popupColor);
+}
+
+$arrowSize: 10px;
+
+.arrow {
+  position: absolute;
+  width: $arrowSize;
+  height: $arrowSize;
+}
+
+.arrow::before {
+  content: "";
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: $popupColor;
+  transform: rotate(45deg);
+  z-index: -1;
+}
+
+.popup[data-popper-placement="top"] .arrow {
+  bottom: -0.5 * $arrowSize;
+}
+
+.popup[data-popper-placement="bottom"] .arrow {
+  top: -0.5 * $arrowSize;
+}
+
+.popup[data-popper-placement="left"] .arrow {
+  right: -0.5 * $arrowSize;
+}
+
+.popup[data-popper-placement="right"] .arrow {
+  left: -0.5 * $arrowSize;
+}

--- a/components/Footnote/index.module.scss
+++ b/components/Footnote/index.module.scss
@@ -56,11 +56,13 @@ $popupColor: $gray-300;
 }
 .popupContent::before {
   top: 0;
-  background: linear-gradient(to bottom, $popupColor, transparent);
+  // Weirdly, just using a gradient from color -> transparent doesn't work in Safari
+  // because of the way it interpolates between colors.
+  background: linear-gradient(to bottom, $popupColor, rgba($popupColor, 0));
 }
 .popupContent::after {
   bottom: 0;
-  background: linear-gradient(to bottom, transparent, $popupColor);
+  background: linear-gradient(to bottom, rgba($popupColor, 0), $popupColor);
 }
 
 $arrowSize: 10px;

--- a/components/Footnote/index.module.scss
+++ b/components/Footnote/index.module.scss
@@ -56,11 +56,11 @@ $popupColor: $gray-300;
 }
 .popupContent::before {
   top: 0;
-  background: linear-gradient($popupColor, transparent);
+  background: linear-gradient(to bottom, $popupColor, transparent);
 }
 .popupContent::after {
   bottom: 0;
-  background: linear-gradient(transparent, $popupColor);
+  background: linear-gradient(to bottom, transparent, $popupColor);
 }
 
 $arrowSize: 10px;

--- a/components/PageContent/index.js
+++ b/components/PageContent/index.js
@@ -1,6 +1,13 @@
-import { useContext, Fragment } from "react";
+import {
+  useContext,
+  Fragment,
+  Children,
+  cloneElement,
+  isValidElement,
+} from "react";
 import { MDXRemote } from "next-mdx-remote";
 import Section from "../Section";
+import Footnote from "../Footnote";
 import components from "../";
 import { PageContext } from "../../pages/_app";
 
@@ -18,9 +25,119 @@ const PageContent = () => {
   if (!source) return null;
   return (
     <Wrapper>
-      <MDXRemote {...source} components={components} />
+      <MDXRemote
+        {...source}
+        components={{ ...components, wrapper: MDXWrapper }}
+      />
     </Wrapper>
   );
 };
 
 export default PageContent;
+
+/*
+  We are using MDXWrapper in a hacky way to customize the way tooltips appear
+  by manipulating the react children directly.
+*/
+
+function MDXWrapper({ children }) {
+  let footnotesComponent = null;
+
+  Children.forEach(children, (child) => {
+    if (child.props.className === "footnotes") {
+      footnotesComponent = child;
+    }
+  });
+
+  if (!footnotesComponent) return <div>{children}</div>;
+
+  let footnotesOl = null;
+  Children.forEach(footnotesComponent.props.children, (child) => {
+    if (child.props.mdxType === "ol") {
+      footnotesOl = child;
+    }
+  });
+
+  if (!footnotesOl) {
+    console.error(
+      "Unexpected dom layout: Footnotes div didn't contain an <ol>."
+    );
+    return <div>{children}</div>;
+  }
+
+  const footnotes = Children.toArray(footnotesOl.props.children);
+  const links = getFootenoteLinks(children);
+
+  // `footnotes` and `links` should correspond 1-to-1
+  // So now we can replace each link with a tooltip containing
+  // the footnote content.
+  let mapping = new Map();
+  for (let i = 0; i < links.length; i++) {
+    const link = links[i];
+    const footnote = footnotes[i];
+
+    const label = Children.only(link.props.children).props.children;
+    const content = replaceChildren(footnote.props.children, (child) => {
+      if (child.props && child.props.className === "footnote-backref") {
+        return null;
+      }
+      return undefined;
+    });
+
+    mapping.set(links[i], <Footnote label={label}>{content}</Footnote>);
+  }
+
+  mapping.set(footnotesComponent, null);
+
+  return (
+    <div>
+      {replaceChildren(children, (child) => {
+        if (mapping.has(child)) return mapping.get(child);
+        return undefined;
+      })}
+    </div>
+  );
+}
+
+function getFootenoteLinks(children) {
+  let links = [];
+
+  Children.forEach(children, (child) => {
+    if (typeof child === "string") return;
+
+    // Expect footnote links to look like this:
+    // <sup id="fnref-N"><a className="footnote-ref">N</a></sup>
+    if (
+      child.props.mdxType === "sup" &&
+      child.props.id.startsWith("fnref-") &&
+      Children.count(child.props.children) === 1 &&
+      Children.only(child.props.children).props.className === "footnote-ref"
+    ) {
+      // If it's a match, add the <sup> element to `links`.
+      links.push(child);
+      return;
+    }
+
+    links.push(...getFootenoteLinks(child.props.children));
+  });
+
+  return links;
+}
+
+function replaceChildren(children, mapping) {
+  return Children.map(children, (child) => {
+    const mapped = mapping(child);
+    if (mapped !== undefined) {
+      return mapped;
+    }
+
+    if (!isValidElement(child)) return child;
+
+    if (Children.count(child.props.children) === 0) return child;
+
+    return cloneElement(child, {
+      ...child.props,
+      children: replaceChildren(child.props.children, mapping),
+    });
+  });
+}

--- a/public/content/lessons/testbed-lesson.mdx
+++ b/public/content/lessons/testbed-lesson.mdx
@@ -240,3 +240,9 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
 <Interactive filename="test-interactive">
   {() => ({ startValue: 1000 })}
 </Interactive>
+
+This is some text with a footnote.[^1] Pretty cool, right!?
+
+[^1]: Hello, world!
+
+    What's up?


### PR DESCRIPTION
Website change review checklist:
- [x] I have requested a review from the appropriate persons
- [x] I have checked that my changes work in the preview
- [x] I have checked that the rest of the site is still functioning in the preview
- [x] I have checked that my content/code is consistent with existing content/code
- [x] I have used components in the places and ways they are intended (see the readme)
- [x] I have formatted all of my code with Prettier

This pull request:
- Creates an inline footnote component
- Manhandles the output of the MDX parser, which always just spits footnotes out at the bottom, to force them into their inline locations