### PR TITLE
Add PropTypes for components

### DIFF
--- a/components/Accordion/index.js
+++ b/components/Accordion/index.js
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import Markdownify from "../Markdownify";
+import PropTypes from "prop-types";
 import styles from "./index.module.scss";
 
 /*
@@ -9,8 +10,18 @@ import styles from "./index.module.scss";
   which is necessary for Netlify to find them at build time.
 */
 
+Accordion.propTypes = {
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  preserveInnerState: PropTypes.bool,
+};
+
 // expandable/collapsible section, like <details>
-const Accordion = ({ title, children, preserveInnerState = false }) => {
+export default function Accordion({
+  title,
+  children,
+  preserveInnerState = false,
+}) {
   const [open, setOpen] = useState(false);
 
   if (!title && !children) return null;
@@ -33,6 +44,4 @@ const Accordion = ({ title, children, preserveInnerState = false }) => {
       )}
     </div>
   );
-};
-
-export default Accordion;
+}

--- a/components/Center/index.js
+++ b/components/Center/index.js
@@ -1,4 +1,5 @@
 import { forwardRef } from "react";
+import PropTypes from "prop-types";
 import styles from "./index.module.scss";
 
 // util component to flex center its children
@@ -11,4 +12,9 @@ const Center = forwardRef(({ children }, ref) => {
     </div>
   );
 });
+
+Center.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
 export default Center;

--- a/components/Chip/index.js
+++ b/components/Chip/index.js
@@ -1,14 +1,36 @@
 import Tooltip from "../Tooltip";
+import PropTypes from "prop-types";
 import styles from "./index.module.scss";
 
-// generic chip component with text and icon
-const Chip = ({ text, icon, mini = false, tooltip }) => (
-  <Tooltip content={tooltip}>
-    <span className={styles.chip} data-mini={mini}>
-      {icon && <i className={icon} />}
-      {text}
-    </span>
-  </Tooltip>
-);
+Chip.propTypes = {
+  text: requireTextOrIcon,
+  icon: requireTextOrIcon,
+  mini: PropTypes.bool,
+  tooltip: PropTypes.node,
+};
 
-export default Chip;
+function requireTextOrIcon(props, propName, componentName) {
+  if (!props.text && !props.icon) {
+    return new Error(`${componentName} requires one of "text" or "icon"`);
+  }
+
+  if (propName === "text" && !props.icon && typeof props.text !== "string") {
+    return new Error(`text must be a string in ${componentName}`);
+  }
+
+  if (propName === "icon" && !props.text && typeof props.icon !== "string") {
+    return new Error(`icon must be a string in ${componentName}`);
+  }
+}
+
+// generic chip component with text and icon
+export default function Chip({ text, icon, mini = false, tooltip }) {
+  return (
+    <Tooltip content={tooltip}>
+      <span className={styles.chip} data-mini={mini}>
+        {icon && <i className={icon} />}
+        {text}
+      </span>
+    </Tooltip>
+  );
+}

--- a/components/Clickable/index.js
+++ b/components/Clickable/index.js
@@ -1,9 +1,52 @@
 import NextLink from "next/link";
+import PropTypes from "prop-types";
 import Tooltip from "../Tooltip";
 import styles from "./index.module.scss";
 
+Clickable.propTypes = {
+  link: requireLinkOrOnClick,
+  onClick: requireLinkOrOnClick,
+  icon: requireTextOrIcon,
+  text: requireTextOrIcon,
+  design: PropTypes.oneOf(["normal", "rounded"]),
+  active: PropTypes.bool,
+  className: PropTypes.string,
+};
+
+function requireLinkOrOnClick(props, propName, componentName) {
+  if (!props.link && !props.onClick) {
+    return new Error(`${componentName} requires one of "link" or "onClick"`);
+  }
+
+  if (propName === "link" && !props.onClick && typeof props.link !== "string") {
+    return new Error(`link must be a string in ${componentName}`);
+  }
+
+  if (
+    propName === "onClick" &&
+    !props.link &&
+    typeof props.onClick !== "function"
+  ) {
+    return new Error(`onClick must be a function in ${componentName}`);
+  }
+}
+
+function requireTextOrIcon(props, propName, componentName) {
+  if (!props.text && !props.icon) {
+    return new Error(`${componentName} requires one of "text" or "icon"`);
+  }
+
+  if (propName === "text" && !props.icon && typeof props.text !== "string") {
+    return new Error(`text must be a string in ${componentName}`);
+  }
+
+  if (propName === "icon" && !props.text && typeof props.icon !== "string") {
+    return new Error(`icon must be a string in ${componentName}`);
+  }
+}
+
 // link/button component
-const Clickable = ({
+export default function Clickable({
   link,
   onClick,
   icon,
@@ -12,7 +55,7 @@ const Clickable = ({
   active,
   className = "",
   ...rest
-}) => {
+}) {
   // decide whether to use button or link
   let Component;
   if (link) Component = Link;
@@ -45,7 +88,7 @@ const Clickable = ({
       {text && <span className={styles.text}>{text}</span>}
     </Component>
   );
-};
+}
 
 // button component, for actions
 const Button = ({ tooltip, ...rest }) => (
@@ -62,5 +105,3 @@ const Link = ({ tooltip, link = "/", ...rest }) => (
     </Tooltip>
   </NextLink>
 );
-
-export default Clickable;

--- a/components/FeatureCard/index.js
+++ b/components/FeatureCard/index.js
@@ -1,24 +1,34 @@
+import PropTypes from "prop-types";
 import Markdownify from "../Markdownify";
 import styles from "./index.module.scss";
 
+FeatureCard.propTypes = {
+  link: PropTypes.string.isRequired,
+  image: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+  width: PropTypes.number,
+  height: PropTypes.number,
+};
+
 // vertical card with image, text, and link
-const FeatureCard = ({
+export default function FeatureCard({
   link,
   image,
   title,
   text,
   width = 300,
   height = 200,
-}) => (
-  <a className={styles.feature_card} href={link} style={{ width }}>
-    <div className={styles.image} style={{ maxHeight: height }}>
-      <img src={image} />
-    </div>
-    <div className={styles.title}>{title}</div>
-    <div className={styles.text}>
-      <Markdownify noParagraph={true}>{text}</Markdownify>
-    </div>
-  </a>
-);
-
-export default FeatureCard;
+}) {
+  return (
+    <a className={styles.feature_card} href={link} style={{ width }}>
+      <div className={styles.image} style={{ maxHeight: height }}>
+        <img src={image} />
+      </div>
+      <div className={styles.title}>{title}</div>
+      <div className={styles.text}>
+        <Markdownify noParagraph={true}>{text}</Markdownify>
+      </div>
+    </a>
+  );
+}

--- a/components/Figure/index.js
+++ b/components/Figure/index.js
@@ -1,10 +1,38 @@
 import { useState, useRef, useEffect, useContext, useCallback } from "react";
+import PropTypes from "prop-types";
 import Markdownify from "../Markdownify";
 import Clickable from "../Clickable";
 import { bucket } from "../../data/site.yaml";
 import { PageContext } from "../../pages/_app";
 import styles from "./index.module.scss";
 import { useSectionWidth } from "../Section";
+
+Figure.propTypes = {
+  id: PropTypes.string,
+  image: requireImageOrVideo,
+  video: requireImageOrVideo,
+  show: PropTypes.oneOf(["image", "video"]),
+  caption: PropTypes.string,
+  imageCaption: PropTypes.string,
+  videoCaption: PropTypes.string,
+  width: PropTypes.number,
+  height: PropTypes.number,
+  loop: PropTypes.bool,
+};
+
+function requireImageOrVideo(props, propName, componentName) {
+  if (!props.image && !props.video) {
+    return new Error(`${componentName} requires one of "image" or "video"`);
+  }
+
+  if (propName === "image" && !props.video && typeof props.image !== "string") {
+    return new Error(`image must be a string in ${componentName}`);
+  }
+
+  if (propName === "video" && !props.image && typeof props.video !== "string") {
+    return new Error(`video must be a string in ${componentName}`);
+  }
+}
 
 // change provided srcs (png & mp4) to external bucket location for production.
 const transformSrc = (src, dir) => {
@@ -35,7 +63,7 @@ const autoSize = ({ width, height }, sectionWidth) => {
 
 // figure component to show image and/or video and caption, with controls to
 // switch between
-const Figure = ({
+export default function Figure({
   id = "",
   image: imageSrc = "",
   video: videoSrc = "",
@@ -46,7 +74,7 @@ const Figure = ({
   width: manualWidth = 0,
   height: manualHeight = 0,
   loop = false,
-}) => {
+}) {
   // whether to show image or video
   initialShow =
     initialShow || (imageSrc ? "image" : "") || (videoSrc ? "video" : "") || "";
@@ -159,6 +187,4 @@ const Figure = ({
       )}
     </figure>
   );
-};
-
-export default Figure;
+}

--- a/components/Footnote/index.js
+++ b/components/Footnote/index.js
@@ -1,7 +1,13 @@
 import { useEffect, useState } from "react";
+import PropTypes from "prop-types";
 import { createPortal } from "react-dom";
 import { usePopper } from "react-popper";
 import styles from "./index.module.scss";
+
+Footnote.propTypes = {
+  label: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
 
 export default function Footnote({ label, children }) {
   const [isOpen, setIsOpen] = useState(false);

--- a/components/FreeResponse/index.js
+++ b/components/FreeResponse/index.js
@@ -1,9 +1,14 @@
 import { useState } from "react";
+import PropTypes from "prop-types";
 import Clickable from "../Clickable";
 import Tooltip from "../Tooltip";
 import styles from "./index.module.scss";
 
-export default function FreeResponse({ children: explanation }) {
+FreeResponse.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default function FreeResponse({ children }) {
   const [userAnswer, setUserAnswer] = useState("");
 
   const [submitted, setSubmitted] = useState(false);
@@ -41,7 +46,7 @@ export default function FreeResponse({ children: explanation }) {
 
       <div className={styles.answerHeader}>Our answer:</div>
       <div className={styles.ours} data-visible={submitted}>
-        <div className={styles.explanation}>{explanation}</div>
+        <div className={styles.explanation}>{children}</div>
       </div>
     </div>
   );

--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import Background from "./background";
 import Tooltip from "../Tooltip";
 import Logo from "../Logo";

--- a/components/HomepageFeaturedContent/index.js
+++ b/components/HomepageFeaturedContent/index.js
@@ -7,10 +7,16 @@ import {
   useRef,
   useState,
 } from "react";
+import PropTypes from "prop-types";
 import Clickable from "../Clickable";
 import SocialIcons from "../SocialIcons";
 import Link from "next/link";
 import styles from "./index.module.scss";
+
+HomepageFeaturedContent.propTypes = {
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
 
 export default function HomepageFeaturedContent({ title, children }) {
   return (
@@ -28,6 +34,12 @@ export default function HomepageFeaturedContent({ title, children }) {
 }
 
 const FeaturedItemContext = createContext({ lesson: null });
+
+HomepageFeaturedItem.propTypes = {
+  lesson: PropTypes.string.isRequired,
+  caption: PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
+};
 
 export function HomepageFeaturedItem({ lesson, caption, children }) {
   return (
@@ -58,6 +70,16 @@ export function HomepageFeaturedItem({ lesson, caption, children }) {
     </FeaturedItemContext.Provider>
   );
 }
+
+HomepageFeaturedVideo.propTypes = {
+  src: PropTypes.string.isRequired,
+  autoPlay: PropTypes.bool,
+  loop: PropTypes.bool,
+  muted: PropTypes.bool,
+  controls: PropTypes.bool,
+  width: PropTypes.number,
+  height: PropTypes.number,
+};
 
 export function HomepageFeaturedVideo({
   src,

--- a/components/Interactive/index.js
+++ b/components/Interactive/index.js
@@ -1,10 +1,21 @@
 import { useState, useEffect, useRef, useContext } from "react";
+import PropTypes from "prop-types";
 import { PageContext } from "../../pages/_app";
 import { useForceUpdate } from "../../util/hooks";
 import styles from "./index.module.scss";
 
+Interactive.propTypes = {
+  filename: PropTypes.string.isRequired,
+  children: PropTypes.func,
+  aspectRatio: PropTypes.number,
+};
+
 // dynamically load (from same directory as page) and embed a react applet
-const Interactive = ({ filename, children = [], aspectRatio = 16 / 9 }) => {
+export default function Interactive({
+  filename,
+  children = [],
+  aspectRatio = 16 / 9,
+}) {
   const { dir } = useContext(PageContext);
   const forceUpdate = useForceUpdate();
   // store dynamically loaded component in ref because react doesn't like a
@@ -87,6 +98,4 @@ const Interactive = ({ filename, children = [], aspectRatio = 16 / 9 }) => {
       </div>
     </div>
   );
-};
-
-export default Interactive;
+}

--- a/components/LessonCard/index.js
+++ b/components/LessonCard/index.js
@@ -1,4 +1,5 @@
 import { useContext } from "react";
+import PropTypes from "prop-types";
 import NextLink from "next/link";
 import Chip from "../Chip";
 import { formatDate } from "../../util/locale";
@@ -6,8 +7,18 @@ import { PageContext } from "../../pages/_app";
 import styles from "./index.module.scss";
 import Tooltip from "../Tooltip";
 
+LessonCard.propTypes = {
+  id: PropTypes.string.isRequired,
+  icon: PropTypes.string,
+  mini: PropTypes.bool,
+  reverse: PropTypes.bool,
+  tooltip: PropTypes.node,
+  active: PropTypes.bool,
+  className: PropTypes.string,
+};
+
 // button that links to a lesson, showing details like thumbnail, title, etc.
-const LessonCard = ({
+export default function LessonCard({
   id,
   icon,
   mini,
@@ -15,7 +26,7 @@ const LessonCard = ({
   tooltip,
   active,
   className = "",
-}) => {
+}) {
   const { lessons = [] } = useContext(PageContext);
 
   // find lesson with matching slug
@@ -78,9 +89,7 @@ const LessonCard = ({
       </div>
     </Component>
   );
-};
-
-export default LessonCard;
+}
 
 const Link = ({ link, tooltip, ...rest }) => (
   <NextLink href={link} passHref>

--- a/components/LessonGallery/index.js
+++ b/components/LessonGallery/index.js
@@ -1,4 +1,5 @@
 import { useContext, useMemo, useState } from "react";
+import PropTypes from "prop-types";
 import Link from "next/link";
 import Center from "../Center";
 import Clickable from "../Clickable";
@@ -8,8 +9,12 @@ import { PageContext } from "../../pages/_app";
 import styles from "./index.module.scss";
 import PiCreature from "../PiCreature";
 
+LessonGallery.propTypes = {
+  show: PropTypes.oneOf(["topic", "all"]),
+};
+
 // gallery that shows all lessons in various ways with tabs. show by topic or all
-const LessonGallery = ({ show = "topic" }) => {
+export default function LessonGallery({ show = "topic" }) {
   const { lessons } = useContext(PageContext);
   const [tab, setTab] = useState(show); // active tab
 
@@ -89,9 +94,7 @@ const LessonGallery = ({ show = "topic" }) => {
       )}
     </>
   );
-};
-
-export default LessonGallery;
+}
 
 const TopicCard = ({ topic }) => {
   return (

--- a/components/LessonLink/index.js
+++ b/components/LessonLink/index.js
@@ -1,10 +1,15 @@
+import PropTypes from "prop-types";
 import Link from "next/link";
 import Tooltip from "../Tooltip";
 import LessonCard from "../LessonCard";
 
+LessonLink.propTypes = {
+  id: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
 // plain text link to another lesson from markdown, with tooltip preview
-const LessonLink = ({ id, children }) => {
-  id = id || "";
+export default function LessonLink({ id = "", children }) {
   const tooltip = <LessonCard id={id} mini={true} />;
 
   return (
@@ -14,6 +19,4 @@ const LessonLink = ({ id, children }) => {
       </Tooltip>
     </Link>
   );
-};
-
-export default LessonLink;
+}

--- a/components/LessonNav/index.js
+++ b/components/LessonNav/index.js
@@ -24,13 +24,15 @@ const LessonNav = () => {
     <Section>
       <div className={styles.lesson_nav}>
         <div className={styles.controls}>
-          <LessonCard
-            id={prev}
-            mini={true}
-            icon="fas fa-arrow-left"
-            tooltip="Previous lesson"
-            className={styles.prev}
-          />
+          {prev && (
+            <LessonCard
+              id={prev}
+              mini={true}
+              icon="fas fa-arrow-left"
+              tooltip="Previous lesson"
+              className={styles.prev}
+            />
+          )}
           <Clickable
             icon={open ? "fas fa-times" : "fas fa-bars"}
             className={styles.toggle}
@@ -39,14 +41,16 @@ const LessonNav = () => {
               open ? "Close list" : "See more lessons for topic " + topicName
             }
           />
-          <LessonCard
-            id={next}
-            mini={true}
-            reverse={true}
-            icon="fas fa-arrow-right"
-            tooltip="Next lesson"
-            className={styles.next}
-          />
+          {next && (
+            <LessonCard
+              id={next}
+              mini={true}
+              reverse={true}
+              icon="fas fa-arrow-right"
+              tooltip="Next lesson"
+              className={styles.next}
+            />
+          )}
         </div>
         {open && (
           <div className={styles.list}>

--- a/components/Main/index.js
+++ b/components/Main/index.js
@@ -1,6 +1,11 @@
+import PropTypes from "prop-types";
 import styles from "./index.module.scss";
 
-// simple wrapper component for main section of page
-const Main = ({ children }) => <main className={styles.main}>{children}</main>;
+Main.propTypes = {
+  children: PropTypes.node.isRequired,
+};
 
-export default Main;
+// simple wrapper component for main section of page
+export default function Main({ children }) {
+  return <main className={styles.main}>{children}</main>;
+}

--- a/components/Markdownify/index.js
+++ b/components/Markdownify/index.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import ReactMarkdown from "react-markdown";
 import remarkMath from "remark-13-math";
 import rehypeKatex from "rehype-katex";
@@ -7,9 +8,14 @@ import rehypeKatex from "rehype-katex";
 // thus, have separate 12 and 13 remark versions of remark-math
 // use 13 for this component, 12 for everything else (mdx)
 
+Markdownify.propTypes = {
+  children: PropTypes.node.isRequired,
+  noParagraph: PropTypes.bool,
+};
+
 // component to turn plain string into markdown, useful for making components
 // accept markdown as props
-const Markdownify = ({ children, noParagraph = false }) => {
+export default function Markdownify({ children, noParagraph = false }) {
   if (typeof children === "string") {
     return (
       <ReactMarkdown
@@ -21,6 +27,4 @@ const Markdownify = ({ children, noParagraph = false }) => {
       </ReactMarkdown>
     );
   } else return children;
-};
-
-export default Markdownify;
+}

--- a/components/Patrons/index.js
+++ b/components/Patrons/index.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useContext } from "react";
+import PropTypes from "prop-types";
 import Clickable from "../Clickable";
 import sitePatrons from "../../data/patrons.yaml";
 import nameOverrides from "../../data/patron-name-overrides.yaml";
@@ -6,9 +7,13 @@ import { shuffle } from "../../util/math";
 import { PageContext } from "../../pages/_app";
 import styles from "./index.module.scss";
 
+Patrons.propTypes = {
+  active: PropTypes.bool,
+};
+
 // component to display expandable/collapsible list of patrons, either site-wide
 // or page-specific
-const Patrons = ({ active }) => {
+export default function Patrons({ active }) {
   const [open, setOpen] = useState(false);
   const { patrons: pagePatrons = [] } = useContext(PageContext);
   const [shuffledPagePatrons, setShuffledPagePatrons] = useState(pagePatrons);
@@ -19,10 +24,11 @@ const Patrons = ({ active }) => {
   }, [pagePatrons]);
 
   let patrons;
-  // page specific patrons
-  if (shuffledPagePatrons.length) patrons = shuffledPagePatrons;
-  // site-wide patrons
-  else
+  if (shuffledPagePatrons.length) {
+    // page specific patrons
+    patrons = shuffledPagePatrons;
+  } else {
+    // site-wide patrons
     patrons =
       // filter by amount, active status, and top 1000 for css grid limits
       sitePatrons
@@ -32,6 +38,7 @@ const Patrons = ({ active }) => {
         .map((patron) => nameOverrides[patron] || patron)
         .filter((patron) => patron)
         .slice(0, 1000);
+  }
 
   if (!patrons.length) return null;
 
@@ -49,6 +56,4 @@ const Patrons = ({ active }) => {
       />
     </>
   );
-};
-
-export default Patrons;
+}

--- a/components/PiCreature/index.js
+++ b/components/PiCreature/index.js
@@ -1,24 +1,33 @@
 import { Fragment } from "react";
+import PropTypes from "prop-types";
 import Markdownify from "../Markdownify";
 import styles from "./index.module.scss";
 import SpeechBubble from "../../public/images/pi-creatures/bubble-speech.svg";
 import ThoughtBubble from "../../public/images/pi-creatures/bubble-thought.svg";
 import { useSectionWidth } from "../Section";
 
+PiCreature.propTypes = {
+  emotion: PropTypes.string,
+  text: PropTypes.string,
+  thought: PropTypes.bool,
+  placement: PropTypes.oneOf(["side", "auto", "inline"]),
+  flip: PropTypes.bool,
+  design: PropTypes.oneOf(["small", "big"]),
+};
+
 // pi creature/character, with "smart" positioning, and speech/thought bubble
-const PiCreature = ({
+export default function PiCreature({
   emotion = "hooray",
   text,
-  thought,
-  placement,
-  flip,
+  thought = false,
+  placement = "auto",
+  flip = false,
   design,
-}) => {
+}) {
   // bubble component
   let Bubble = Fragment;
   if (text) {
-    if (thought) Bubble = ThoughtBubble;
-    else Bubble = SpeechBubble;
+    Bubble = thought ? ThoughtBubble : SpeechBubble;
   }
 
   const sectionWidth = useSectionWidth();
@@ -26,14 +35,17 @@ const PiCreature = ({
   return (
     <div
       className={styles.pi_creature}
-      data-flip={flip || false}
-      data-placement={placement || "auto"}
+      data-flip={flip}
+      data-placement={placement}
       data-design={design}
       data-text={text ? true : false}
       data-sectionwidth={sectionWidth}
     >
       <div className={styles.frame}>
-        <img src={`/images/pi-creatures/${emotion}.svg`} />
+        <img
+          src={`/images/pi-creatures/${emotion}.svg`}
+          alt={`${emotion} pi creature`}
+        />
         <Bubble />
         {text && (
           <div className={styles.text}>
@@ -43,6 +55,4 @@ const PiCreature = ({
       </div>
     </div>
   );
-};
-
-export default PiCreature;
+}

--- a/components/Portrait/index.js
+++ b/components/Portrait/index.js
@@ -1,9 +1,16 @@
+import PropTypes from "prop-types";
 import { useSectionWidth } from "../Section";
 import styles from "./index.module.scss";
 
+Portrait.propTypes = {
+  image: PropTypes.string.isRequired,
+  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  flip: PropTypes.bool,
+};
+
 // circular image that floats to left/right of text content, useful for pictures
 // of people
-const Portrait = ({ image, size = "180px", flip = false }) => {
+export default function Portrait({ image, size = "180px", flip = false }) {
   const sectionWidth = useSectionWidth();
 
   // if no image, don't render
@@ -19,6 +26,4 @@ const Portrait = ({ image, size = "180px", flip = false }) => {
       <img src={image} />
     </div>
   );
-};
-
-export default Portrait;
+}

--- a/components/Question/index.js
+++ b/components/Question/index.js
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import PropTypes from "prop-types";
 import Clickable from "../Clickable";
 import PiCreature from "../PiCreature";
 import Markdownify from "../Markdownify";
@@ -6,11 +7,22 @@ import { shakeElement } from "../../util/animation";
 import styles from "./index.module.scss";
 
 // interactive multiple-choice question component with explanation
+Question.propTypes = {
+  question: PropTypes.string.isRequired,
+  choice1: PropTypes.string.isRequired,
+  choice2: PropTypes.string.isRequired,
+  choice3: PropTypes.string,
+  choice4: PropTypes.string,
+  choice5: PropTypes.string,
+  choice6: PropTypes.string,
+  answer: PropTypes.number.isRequired,
+  children: PropTypes.node,
+};
 
 // component takes choices as enumerated/separate props rather than single array
 // prop, because with array, jsx syntax will escape math latex like
 // "\times" -> "[TAB]imes"
-const Question = ({
+export default function Question({
   question,
   choice1,
   choice2,
@@ -20,7 +32,7 @@ const Question = ({
   choice6,
   answer,
   children: explanation,
-}) => {
+}) {
   const [selected, setSelected] = useState(null);
   const [state, setState] = useState("unanswered");
   const resultRef = useRef();
@@ -110,6 +122,4 @@ const Question = ({
       )}
     </div>
   );
-};
-
-export default Question;
+}

--- a/components/Section/index.js
+++ b/components/Section/index.js
@@ -1,27 +1,38 @@
 import { createContext, useContext } from "react";
+import PropTypes from "prop-types";
 import styles from "./index.module.scss";
 
 // section wrapper component that spans entire width of screen and colors
 // background in alternating white/off-white
+Section.propTypes = {
+  children: PropTypes.node.isRequired,
+  dark: PropTypes.bool,
+  width: PropTypes.oneOf(["narrow", "normal", "full"]),
+};
 
 // make sure markdown starts and ends with this component, or doesn't use it at
 // all. see PageContent component.
 const SectionContext = createContext({ width: "normal" });
 
-const Section = ({ children, dark, width = "normal", ...props }) => (
-  <SectionContext.Provider value={{ width }}>
-    <section
-      {...props}
-      className={styles.section}
-      data-dark={dark}
-      data-width={width}
-    >
-      <div className={styles.wrapper}>{children}</div>
-    </section>
-  </SectionContext.Provider>
-);
-
-export default Section;
+export default function Section({
+  children,
+  dark = false,
+  width = "normal",
+  ...props
+}) {
+  return (
+    <SectionContext.Provider value={{ width }}>
+      <section
+        {...props}
+        className={styles.section}
+        data-dark={dark}
+        data-width={width}
+      >
+        <div className={styles.wrapper}>{children}</div>
+      </section>
+    </SectionContext.Provider>
+  );
+}
 
 export function useSectionWidth() {
   const { width } = useContext(SectionContext);

--- a/components/ShareButtons/index.js
+++ b/components/ShareButtons/index.js
@@ -1,7 +1,13 @@
 import { useRouter } from "next/router";
+import PropTypes from "prop-types";
 import Clickable from "../Clickable";
 import SocialIcons from "../SocialIcons";
 import styles from "./index.module.scss";
+
+ShareButtons.propTypes = {
+  url: PropTypes.string,
+  text: PropTypes.string,
+};
 
 export default function ShareButtons({ url, text = "" }) {
   const router = useRouter();
@@ -27,19 +33,19 @@ export default function ShareButtons({ url, text = "" }) {
         Enjoy this lesson? Consider sharing it.
       </div>
       <Clickable
-        link={twitterURL}
+        link={twitterURL.href}
         text="Twitter"
         icon="fab fa-twitter"
         target="_blank"
       />
       <Clickable
-        link={facebookURL}
+        link={facebookURL.href}
         text="Facebook"
         icon="fab fa-facebook"
         target="_blank"
       />
       <Clickable
-        link={redditURL}
+        link={redditURL.href}
         text="Reddit"
         icon="fab fa-reddit"
         target="_blank"

--- a/components/Spoiler/index.js
+++ b/components/Spoiler/index.js
@@ -1,10 +1,15 @@
+import PropTypes from "prop-types";
 import styles from "./index.module.scss";
 
-// blacked-out span of text that reveals itself on hover/focus
-const Spoiler = ({ children }) => (
-  <span className={styles.spoiler} tabIndex="0">
-    {children}
-  </span>
-);
+Spoiler.propTypes = {
+  children: PropTypes.node.isRequired,
+};
 
-export default Spoiler;
+// blacked-out span of text that reveals itself on hover/focus
+export default function Spoiler({ children }) {
+  return (
+    <span className={styles.spoiler} tabIndex="0">
+      {children}
+    </span>
+  );
+}

--- a/components/Tooltip/index.js
+++ b/components/Tooltip/index.js
@@ -8,6 +8,7 @@ import {
   Children,
 } from "react";
 import { createPortal } from "react-dom";
+import PropTypes from "prop-types";
 import { usePopper } from "react-popper";
 import Markdownify from "../Markdownify";
 import classNames from "./index.module.scss";
@@ -139,5 +140,10 @@ const Tooltip = forwardRef(({ content, children, ...rest }, ref) => {
     </>
   );
 });
+
+Tooltip.propTypes = {
+  content: PropTypes.node,
+  children: PropTypes.node.isRequired,
+};
 
 export default Tooltip;

--- a/components/TopicHeader/index.js
+++ b/components/TopicHeader/index.js
@@ -1,5 +1,14 @@
+import PropTypes from "prop-types";
 import Section from "../Section";
 import styles from "./index.module.scss";
+
+TopicHeader.propTypes = {
+  topic: PropTypes.shape({
+    slug: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    description: PropTypes.string,
+  }),
+};
 
 export default function TopicHeader({ topic }) {
   return (

--- a/components/Twitter/index.js
+++ b/components/Twitter/index.js
@@ -1,14 +1,18 @@
 import { useEffect, useRef } from "react";
+import PropTypes from "prop-types";
+import Center from "../Center";
 import { TwitterTweetEmbed } from "react-twitter-embed";
 
-import Center from "../Center";
-
 // https://github.com/saurabhnemade/react-twitter-embed
+
+Twitter.propTypes = {
+  tweet: PropTypes.string.isRequired,
+};
 
 const width = "500px";
 
 // twitter tweet embed
-const Twitter = ({ tweet }) => {
+export default function Twitter({ tweet }) {
   const ref = useRef();
 
   useEffect(() => {
@@ -36,6 +40,4 @@ const Twitter = ({ tweet }) => {
       <TwitterTweetEmbed tweetId={tweet} />
     </Center>
   );
-};
-
-export default Twitter;
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next-images": "^1.7.0",
     "next-mdx-remote": "3.0.2",
     "next-yaml": "^1.0.1",
+    "prop-types": "^15.7.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-markdown": "^6.0.2",


### PR DESCRIPTION
## Why This Matters
This PR makes it so that if you use a component incorrectly (providing the wrong information, or not providing enough information), you will get an error in your browser's console describing what's wrong and how to fix it.

## Other Info
Website change review checklist:
- [ ] I have requested a review from the appropriate persons
- [x] I have checked that my changes work in the preview
- [x] I have checked that the rest of the site is still functioning in the preview
- [x] I have checked that my content/code is consistent with existing content/code
- [x] I have used components in the places and ways they are intended (see the readme)
- [x] I have formatted all of my code with Prettier

This pull request:
- Adds PropTypes to the vast majority of components
- Closes #99