### PR TITLE
Add FAQ ids and redirect from `/faq` to `/contact`

### DIFF
--- a/components/Accordion/index.js
+++ b/components/Accordion/index.js
@@ -40,7 +40,9 @@ export default function Accordion({
   const toggleOpen = () => {
     if (open) {
       setOpen(false);
-      router.replace(router.asPath.split("#")[0]);
+      if (id && router.asPath.split("#")[1] !== undefined) {
+        router.replace(router.asPath.split("#")[0]);
+      }
     } else {
       setOpen(true);
       if (id) {

--- a/components/Accordion/index.js
+++ b/components/Accordion/index.js
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
+import { useRouter } from "next/router";
 import Markdownify from "../Markdownify";
 import PropTypes from "prop-types";
 import styles from "./index.module.scss";
@@ -14,6 +15,7 @@ Accordion.propTypes = {
   title: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   preserveInnerState: PropTypes.bool,
+  id: PropTypes.string,
 };
 
 // expandable/collapsible section, like <details>
@@ -21,15 +23,42 @@ export default function Accordion({
   title,
   children,
   preserveInnerState = false,
+  id,
 }) {
   const [open, setOpen] = useState(false);
+
+  const router = useRouter();
+  const ref = useRef();
+
+  useEffect(() => {
+    // Once on mount, check if url #hash matches id, and if so, open
+    if (id && router.asPath.split("#")[1] === id) {
+      setOpen(true);
+    }
+  }, []);
+
+  const toggleOpen = () => {
+    if (open) {
+      setOpen(false);
+      router.replace(router.asPath.split("#")[0]);
+    } else {
+      setOpen(true);
+      if (id) {
+        ref.current.removeAttribute("id");
+        router.replace(`#${id}`);
+        setTimeout(() => {
+          ref.current.id = id;
+        }, 1);
+      }
+    }
+  };
 
   if (!title && !children) return null;
 
   return (
-    <div className={styles.accordion}>
+    <div className={styles.accordion} id={id} ref={ref}>
       {title && (
-        <button className={styles.title} onClick={() => setOpen(!open)}>
+        <button className={styles.title} onClick={toggleOpen}>
           <i className={open ? "fas fa-angle-up" : "fas fa-angle-down"} />
           {title}
         </button>

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,7 @@
 
 [context.deploy-preview]
   command = "yarn build"
+
+[[redirects]]
+  from = "/faq"
+  to = "/contact"

--- a/next.config.js
+++ b/next.config.js
@@ -5,20 +5,6 @@ let config = {
   target: "serverless",
 };
 
-// URL Redirects
-config = {
-  ...config,
-  async redirects() {
-    return [
-      {
-        source: "/faq",
-        destination: "/contact",
-        permanent: false,
-      },
-    ];
-  },
-};
-
 config = {
   ...config,
   sassOptions: {

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,20 @@ let config = {
   target: "serverless",
 };
 
+// URL Redirects
+config = {
+  ...config,
+  async redirects() {
+    return [
+      {
+        source: "/faq",
+        destination: "/contact",
+        permanent: false,
+      },
+    ];
+  },
+};
+
 config = {
   ...config,
   sassOptions: {

--- a/public/content/contact.mdx
+++ b/public/content/contact.mdx
@@ -6,8 +6,7 @@
 
 # Frequently Asked Questions
 
-
-<Accordion title="What do you use to animate your videos?">
+<Accordion title="What do you use to animate your videos?" id="manim">
 
 <Figure image="../images/contact/manim_wide.png" width="500px" />
 
@@ -29,7 +28,7 @@ Where programatic animations works best is when you have a situation where the c
 
 </Accordion>
 
-<Accordion title="Will you please make a video on [some topic]?">
+<Accordion title="Will you please make a video on [some topic]?" id="request">
 
 <Center>
   <Clickable
@@ -44,7 +43,7 @@ That reddit thread is the only place I look when considering community suggestio
 
 </Accordion>
 
-<Accordion title="What does the name 3blue1brown refer to?">
+<Accordion title="What does the name 3blue1brown refer to?" id="name">
 
 <Portrait image="images/contact/logo.svg" size="125px" />
 
@@ -54,7 +53,7 @@ In the same way that many channels simply share their name with the author, a yo
 
 </Accordion>
 
-<Accordion title="What's the music playing in your videos?">
+<Accordion title="What's the music playing in your videos?" id="music">
 
 <Portrait image="images/contact/vince-bandcamp-portrait.jpeg" />
 
@@ -64,7 +63,7 @@ If you are interested in using this music, see [this form](https://vincerubinett
 
 </Accordion>
 
-<Accordion title="Can I translate your videos?">
+<Accordion title="Can I translate your videos?" id="translate">
 
 Recently, YouTube stopped supporting the [built-in tools](https://support.google.com/youtube/answer/6054623?hl=en) they once had for the community to submit subtitles. We will adopt some solution to let the community submit subtitles again soon, but at the moment nothing is set in stone. Stay tuned!
 
@@ -106,7 +105,7 @@ Current translated channels.
 
 </Accordion>
 
-<Accordion title="What books/resources do you recommend for learning math?">
+<Accordion title="What books/resources do you recommend for learning math?" id="books">
 
 <Center>
   <Clickable
@@ -118,13 +117,13 @@ Current translated channels.
 
 </Accordion>
 
-<Accordion title="Can you answer a math question for me?">
+<Accordion title="Can you answer a math question for me?" id="math-question">
 
 I'd prefer that you post it to the [3b1b subreddit](https://www.reddit.com/r/3blue1brown). That way, even if I'm too busy to answer (or if I don't know!), there's a good chance someone else will help you. You should also post it to the [math stack exchange](https://math.stackexchange.com/), or to [Quora](https://www.quora.com/topic/Mathematics), where you'll be exposed to many, many great minds who are eager to help you out.
 
 </Accordion>
 
-<Accordion title="I’ve solved a famous unsolved math problem/developed a novel idea.  Will you check it for me?">
+<Accordion title="I’ve solved a famous unsolved math problem/developed a novel idea. Will you check it for me?" id="unsolved">
 
 Unfortunately, no. There are two important things to note here:
 
@@ -133,19 +132,19 @@ Unfortunately, no. There are two important things to note here:
 
 </Accordion>
 
-<Accordion title="Will you speak at my event?">
+<Accordion title="Will you speak at my event?" id="speaking">
 
 Maybe! Feel free to share the details through the contact form below. Just know my main focus will always be the videos, so talks are typically kept to a minimum.
 
 </Accordion>
 
-<Accordion title="My organization would like to sponsor one of your videos.">
+<Accordion title="My organization would like to sponsor one of your videos." id="sponsor">
 
 The channel [no longer does sponsored videos](https://www.patreon.com/posts/going-sponsor-19586800).
 
 </Accordion>
 
-<Accordion title="Can I use/license these videos?">
+<Accordion title="Can I use/license these videos?" id="license">
 
 Under the standard YouTube license, you are free to embed the videos in your own site or blog as much as you’d like, as long as it is not behind a paywall. You may not re-upload them to other platforms without permission. If you want to use some of the visuals offline in a classroom, or for a talk/presentation, by all means, feel free to do so. In both cases, attribution is of course appreciated.
 


### PR DESCRIPTION
Website change review checklist:
- [ ] I have requested a review from the appropriate persons
- [x] I have checked that my changes work in the preview
- [x] I have checked that the rest of the site is still functioning in the preview
- [x] I have checked that my content/code is consistent with existing content/code
- [x] I have used components in the places and ways they are intended (see the readme)
- [x] I have formatted all of my code with Prettier

This pull request:
- Adds ids to the accordions on the FAQ/contact page so that old links keep working
- Adds a redirect from `/faq` to `/contact` so that old links keep working
- Closes #121