### PR TITLE
Use .mp4 instead of .mov in Bitcoin lesson

### DIFF
--- a/public/content/lessons/2017/bitcoin/broadcast-transaction.mov
+++ b/public/content/lessons/2017/bitcoin/broadcast-transaction.mov
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06663bb21fde1b429bb45eb450d20d181c912dda06a56ed95de61dadbd82be28
-size 3530487

--- a/public/content/lessons/2017/bitcoin/broadcast-transaction.mp4
+++ b/public/content/lessons/2017/bitcoin/broadcast-transaction.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2dec3fa0c42b45faa617a7c0ba5909bb1c38c3493f2c81a3ab82e177526fe05
+size 558630

--- a/public/content/lessons/2017/bitcoin/charlie-leaves.mov
+++ b/public/content/lessons/2017/bitcoin/charlie-leaves.mov
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e6ed67ef5f492d9813347cd345384b182b2c409e0961e5e55593eefe7f10f3b1
-size 1891331

--- a/public/content/lessons/2017/bitcoin/charlie-leaves.mp4
+++ b/public/content/lessons/2017/bitcoin/charlie-leaves.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b43fe0360c6fd5279f7146e1c06c03e6872646003c150f10bb1c0a43f78add3
+size 199706

--- a/public/content/lessons/2017/bitcoin/exchange-for-usd.mov
+++ b/public/content/lessons/2017/bitcoin/exchange-for-usd.mov
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e21559888346f7548bfc160b413dabc32addf7f82bfe6b674213f53bd0a38ff3
-size 1405487

--- a/public/content/lessons/2017/bitcoin/exchange-for-usd.mp4
+++ b/public/content/lessons/2017/bitcoin/exchange-for-usd.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f316a509077164eb3d76160ed04a8300fae9c061dbdda4a92b3ece79fb177d87
+size 167621

--- a/public/content/lessons/2017/bitcoin/guess-and-check.mov
+++ b/public/content/lessons/2017/bitcoin/guess-and-check.mov
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be922dc22ed3b2bf9e908c3e138088cb7d5d7780e81a346af27a1a7523b52f08
-size 11860199

--- a/public/content/lessons/2017/bitcoin/guess-and-check.mp4
+++ b/public/content/lessons/2017/bitcoin/guess-and-check.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53c865d59858ed318353847703324b60f5564bba94a1962baf3156440709894f
+size 1912100

--- a/public/content/lessons/2017/bitcoin/index.mdx
+++ b/public/content/lessons/2017/bitcoin/index.mdx
@@ -64,7 +64,7 @@ At the end of every month, you all look through the list of transactions and tal
 
 <Figure
   image="tally-up.png"
-  video="tally-up.mov"
+  video="tally-up.mp4"
   show="video"
 />
 
@@ -162,7 +162,7 @@ And with that, we have working digital signatures, which remove a huge aspect of
 ## Removing Cash
 But even still, this relies on an honors system of sorts. Namely, you’re trusting that everyone will actually follow through and settle up in cash at the end of each month. But what if, for example, Charlie racks up thousands of dollars in debt, and then just refuses to show up?
 
-<Figure image="charlie-leaves.png" video="charlie-leaves.mov" show="video" />
+<Figure image="charlie-leaves.png" video="charlie-leaves.mp4" show="video" />
 
 The only real reason to revert to cash to settle up is if some people (*I’m looking at you Charlie*) owe a lot of money. As long as nobody falls into debt, the ledger alone works fine.
 
@@ -207,7 +207,7 @@ You are, of course, free to exchange Ledger Dollars for real US dollars. For exa
 
 <Figure
   image="exchange-for-usd.png"
-  video="exchange-for-usd.mov"
+  video="exchange-for-usd.mp4"
   show="video"
 />
 
@@ -237,7 +237,7 @@ So far, I’ve said that this ledger is in some public place, like a website whe
 
 To remove that bit of trust, we’ll abandon the idea of having one ledger in a central location. Instead, we’ll have everyone keep their own copy of the ledger. Then to make a transaction, like “Alice pays Bob 100 LD”, you broadcast the message into the world for people to hear and record on their own private Ledgers.
 
-<Figure video="broadcast-transaction.mov" />
+<Figure video="broadcast-transaction.mp4" />
 
 Remember this live transaction view from before?
 
@@ -321,7 +321,7 @@ How hard do you think it was for them to find that number? The answer, of course
 
 For a random message, the probability that the hash happens to start with 30 successive zeros is $1$ in $2^{30}$, which is about 1 in a billion. So this person almost certainly had to go through about a *billion* different guesses before finding this special one.
 
-<Figure video="guess-and-check.mov" />
+<Figure video="guess-and-check.mp4" />
 
 But what’s cool is that once you know the number, you can quickly verify that this hash really does start with 30 zeros. In other words, you can verify that they went through a large amount of work without having to go through that same effort yourself. This is called a *proof of work*.
 
@@ -358,7 +358,7 @@ But now that our ledger is split into blocks, we have a bit of an issue. We can�
 
 What this means is that they’ll listen for the transactions being broadcast, collect them into a block, and then do a whole bunch of work to find the special number that makes the hash of this block start with 60 zeros, and broadcast out the block they found.[^4]
 
-<Figure video="miners.mov" />
+<Figure video="miners.mp4" />
 
 To reward a block creator for all this work, when she puts together a block, we’ll allow her to include a special transaction at the top in which she gets, say, 10 Ledger Dollars out of thin air.
 

--- a/public/content/lessons/2017/bitcoin/miners.mov
+++ b/public/content/lessons/2017/bitcoin/miners.mov
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05bc10c44cfc8765f92c5d796e9ce44839e58f202aab99a2b4a00e3467d8d0df
-size 17609339

--- a/public/content/lessons/2017/bitcoin/miners.mp4
+++ b/public/content/lessons/2017/bitcoin/miners.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:981539a84197d63508595f48fd4fa6d2f6958570f40ffc5a76a6f641a7cdf42c
+size 2829947

--- a/public/content/lessons/2017/bitcoin/tally-up.mov
+++ b/public/content/lessons/2017/bitcoin/tally-up.mov
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce2a8866632d75f812d128c3c4106e820871a0800bc93be4299b9477f12b1aa7
-size 1252643

--- a/public/content/lessons/2017/bitcoin/tally-up.mp4
+++ b/public/content/lessons/2017/bitcoin/tally-up.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39b4253d20d8ca398ce2087c188781ab701846864695df5a32fc702c642b9c16
+size 111821


### PR DESCRIPTION
Got sloppy on the Bitcoin lesson. Need to replace all .mov files with .mp4. My bad!