### PR TITLE
Create lesson: sphere-area

### DIFF
--- a/components/FreeResponse/index.module.scss
+++ b/components/FreeResponse/index.module.scss
@@ -54,7 +54,6 @@
 .ours {
   padding: 8px;
   border: 2px solid transparent;
-  background: white;
   transition: all 200ms linear;
 
   &[data-visible="false"] {
@@ -62,6 +61,11 @@
       filter: blur(8px);
       user-select: none;
       pointer-events: none;
+
+      img,
+      video {
+        filter: blur(36px);
+      }
     }
   }
 
@@ -77,5 +81,10 @@
   p {
     line-height: 1.6;
     text-align: left;
+  }
+
+  img,
+  video {
+    transition: filter 200ms linear;
   }
 }

--- a/public/content/lessons/2018/sphere-area/2d-cross-section.mp4
+++ b/public/content/lessons/2018/sphere-area/2d-cross-section.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b04d2ddcd5ef624c27a600ba369f3ac5c75ad64ed85c5ec507f97963d6af9fc3
+size 2353789

--- a/public/content/lessons/2018/sphere-area/2d-cross-section.png
+++ b/public/content/lessons/2018/sphere-area/2d-cross-section.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff22ad0032eed8f2783c7a999f666ac4b5d3fc1f0a51b8425f8a1c37cc73707a
+size 675908

--- a/public/content/lessons/2018/sphere-area/R-and-d.png
+++ b/public/content/lessons/2018/sphere-area/R-and-d.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:142d3e772b816052946c700fb3eb21460720ce5b209f174a9d4598e7a52d2597
+size 800406

--- a/public/content/lessons/2018/sphere-area/R-d-theta.png
+++ b/public/content/lessons/2018/sphere-area/R-d-theta.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ea8fbc711d77e2493c3128e87682070c9e5949641e9ae100514f851eccd2d38
+size 341722

--- a/public/content/lessons/2018/sphere-area/R-over-d.png
+++ b/public/content/lessons/2018/sphere-area/R-over-d.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93021ff91b9a9eb1e735d4d078ba0fcf3a465c1cd5e7b8d17bca9817a3b69aa2
+size 286932

--- a/public/content/lessons/2018/sphere-area/alpha-and-beta.png
+++ b/public/content/lessons/2018/sphere-area/alpha-and-beta.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6dcaa1e467698aa626e2f5d9ed85275722322557db6c52bff358d10480dd2bd
+size 316465

--- a/public/content/lessons/2018/sphere-area/alternating-rings.png
+++ b/public/content/lessons/2018/sphere-area/alternating-rings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bfd50d839da87c60ce62c97ce7a6de1664827e800a0c33b5a91ca95411e005f
+size 576104

--- a/public/content/lessons/2018/sphere-area/average-shadow.mp4
+++ b/public/content/lessons/2018/sphere-area/average-shadow.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a754d54454e6378f4b01ca8ce74bde383a13f3e9a9ced18028806c263c15394d
+size 4592608

--- a/public/content/lessons/2018/sphere-area/average-shadow.png
+++ b/public/content/lessons/2018/sphere-area/average-shadow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed55065054f608d313ff06dc0f16bb0a228117d268ea0abee193f52e806a9ff9
+size 1602527

--- a/public/content/lessons/2018/sphere-area/before-and-after.png
+++ b/public/content/lessons/2018/sphere-area/before-and-after.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cbd6aabab7dea2d4c9ff126e1cd6d0cfff4fcd584663ada5ea3503168313869
+size 706265

--- a/public/content/lessons/2018/sphere-area/direct-proof.png
+++ b/public/content/lessons/2018/sphere-area/direct-proof.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c09e762aaa1db79c618b17f110ea491fb1bc5e123bd38d8b5f8c8ec9dcbe600a
+size 252891

--- a/public/content/lessons/2018/sphere-area/equal-in-limit.png
+++ b/public/content/lessons/2018/sphere-area/equal-in-limit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:753b8d244607f0ae00a0d2658c0f2f64fd3e25886e4b5554cb3c9d667bc69601
+size 1431420

--- a/public/content/lessons/2018/sphere-area/every-2nd-ring.png
+++ b/public/content/lessons/2018/sphere-area/every-2nd-ring.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef642b20d5d02b24e3bcd67b763187e2f9a70a30cd94d5c9b0e74331bd10a536
+size 735787

--- a/public/content/lessons/2018/sphere-area/fit-circles-into-rectangle.mp4
+++ b/public/content/lessons/2018/sphere-area/fit-circles-into-rectangle.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68a0de866eae244a6ec20f6fcced214b12a410afb7d8c0b0b397fb3d6ffa09ae
+size 683513

--- a/public/content/lessons/2018/sphere-area/height-squish-review.png
+++ b/public/content/lessons/2018/sphere-area/height-squish-review.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95dc5f4bdb1efcc94c65367a4db226e45069e0da37c28a4d7708109ff46edee9
+size 344776

--- a/public/content/lessons/2018/sphere-area/height-variation.png
+++ b/public/content/lessons/2018/sphere-area/height-variation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43bcd2e3ed9bab1c4093f727a49c82864bea7c58aef321d731d024f3db71e1dc
+size 359320

--- a/public/content/lessons/2018/sphere-area/index.mdx
+++ b/public/content/lessons/2018/sphere-area/index.mdx
@@ -17,13 +17,13 @@ But have you ever wondered *why* is this true? And I don’t just mean proving t
 
 <PiCreature text="But why?!?" emotion="angry" />
 
-How lovely would it be if there was some shift in perspective that showed how you could nicely and perfectly fit these four circles onto the sphere’s surface?
+How lovely would it be if there was some shift in perspective that showed how you could nicely and perfectly fit those four circles onto the sphere’s surface?
 
 Nothing can be quite that simple, since the curvature of a sphere’s surface is different from the curvature of a flat plane, which is why trying to fit paper around a sphere doesn’t really work.
 
 <Figure image="paper-circle.png" caption="Good luck." />
 
-Nevertheless, I’d like to show you two ways of thinking about this surface area connecting it in a satisfying way to these circles.
+Nevertheless, I’d like to show you two ways of thinking about the surface area of a sphere which connect it in a satisfying way to four circles of the same radius.
 
 <Figure image="two-proofs.png" />
 
@@ -34,11 +34,11 @@ The second line of reasoning is something of my own which draws a more direct li
 And lastly I’ll share why this four-fold relation is not unique to spheres, but is instead one specific instance of a much more general fact for all convex shapes in 3D.
 
 ## First approach
-Starting with a birds eye view here, the idea for the first approach is to show that the surface area of the sphere is the same as the area of a cylinder with the same radius and the same height as the sphere.
+Starting with a bird's eye view here, the idea for the first approach is to show that the surface area of the sphere is the same as the area of a cylinder with the same radius and the same height as the sphere.
 
 <Figure image="sphere-equals-cylinder.png" />
 
-Or, rather, a cylinder without its top and bottom, what you might call the “label” of that cylinder.
+Or, rather, a cylinder without its top and bottom, which you might call the “label” of that cylinder.
 
 <Figure image="label-of-cylinder.png" />
 
@@ -66,9 +66,7 @@ The idea is to approximate the area of the sphere with many tiny rectangles cove
   caption="Each little rectangle on the sphere has the same area as its projection on the cylinder."
 />
 
-But why should that be? Well, there are two competing effects at play here. For each little rectangle, let’s call the side along the latitude lines its width, and the side along the longitude lines its height.
-
-On the one hand, as this rectangle is projected outward, its width will get scaled up.
+But why should that be? Well, there are two competing effects at play here. On the one hand, as this rectangle is projected outward, its width will get scaled up.
 
 <Figure
   image="width-scaled-up.png"
@@ -201,7 +199,7 @@ The basic idea is to relate thin concentric rings of the circle with horizontal 
   caption="Each circle is unwrapped such that a thin ring of the circle corresponds to a thin line of the triangle."
 />
 
-Because the circumference of each such ring increases linearly in proportion to the radius, always equal to $2\pi$ times that radius, when you unwrap them all and line them up, their ends will form a straight line (as opposed to some kind of curvey shape), giving you a triangle with a base of $2\pi r$ and a height of $r$.
+Because the circumference of each such ring increases linearly in proportion to the radius, always equal to $2\pi r$, when you unwrap them all and line them up, their ends will form a straight line (as opposed to some kind of curvey shape), giving you a triangle with a base of $2\pi r$ and a height of $r$.
 
 And four of these unwrapped circles fit into our rectangle, which is in some sense an unwrapped version of the sphere’s surface.
 

--- a/public/content/lessons/2018/sphere-area/index.mdx
+++ b/public/content/lessons/2018/sphere-area/index.mdx
@@ -6,4 +6,423 @@ video: GNcFjFmqEc8
 source: _2018/sphere_area.py
 credits:
 - Lesson by Grant Sanderson
+- Text adaptation by Josh Pullen
 ---
+
+Some of you may have seen in school that the surface area of a sphere is $4\pi R^2$, a suspiciously suggestive formula given that it’s a clean multiple of $\pi R^2$, the area of a circle with the same radius.
+
+<Figure image="sphere-vs-circles.png" />
+
+But have you ever wondered *why* is this true? And I don’t just mean proving this $4\pi R^2$ formula. I mean feeling, viscerally, a connection between the sphere's surface area, and those four circles.
+
+<PiCreature text="But why?!?" emotion="angry" />
+
+How lovely would it be if there was some shift in perspective that showed how you could nicely and perfectly fit these four circles onto the sphere’s surface?
+
+Nothing can be quite that simple, since the curvature of a sphere’s surface is different from the curvature of a flat plane, which is why trying to fit paper around a sphere doesn’t really work.
+
+<Figure image="paper-circle.png" caption="Good luck." />
+
+Nevertheless, I’d like to show you two ways of thinking about this surface area connecting it in a satisfying way to these circles.
+
+<Figure image="two-proofs.png" />
+
+The first is a classic. It's one of the true gems of geometry that all students should experience.
+
+The second line of reasoning is something of my own which draws a more direct line between the sphere and its shadow.
+
+And lastly I’ll share why this four-fold relation is not unique to spheres, but is instead one specific instance of a much more general fact for all convex shapes in 3D.
+
+## First approach
+Starting with a birds eye view here, the idea for the first approach is to show that the surface area of the sphere is the same as the area of a cylinder with the same radius and the same height as the sphere.
+
+<Figure image="sphere-equals-cylinder.png" />
+
+Or, rather, a cylinder without its top and bottom, what you might call the “label” of that cylinder.
+
+<Figure image="label-of-cylinder.png" />
+
+We can unwrap the label to see that it is in fact a simple rectangle.
+
+<Figure image="rectangle.png" video="unwrap-cylinder.mp4" />
+
+The width of this rectangle comes from the cylinder’s circumference, $2\pi R$, and the height comes from the height of the sphere, which is $2R$. Multiplying these already gives the formula $4\pi R^2$.
+
+<Figure image="rectangle-dimensions.png" />
+
+But in the spirit of mathematical playfulness, it’s nice to see how four circles with radius $R$ fit into this. The idea is that you can unwrap each circle into a triangle, without changing its area, and fit these nicely onto our unfolded cylinder label. More on that in a bit.
+
+<!-- We could probably create a still image to convey the same idea -->
+<Figure video="fit-circles-into-rectangle.mp4" />
+
+The more pressing question is why on earth the sphere can be related to the cylinder. This animation is already suggestive of how it works:
+
+<Figure video="sphere-to-cylinder.mp4" />
+
+The idea is to approximate the area of the sphere with many tiny rectangles covering it. We will show that if you project those little rectangles directly outward, as if casting a shadow from little lights positioned on the z-axis, the projection of each rectangle onto the cylinder ends up having the same area as the original rectangle.
+
+<Figure
+  image="projection-equal.png"
+  caption="Each little rectangle on the sphere has the same area as its projection on the cylinder."
+/>
+
+But why should that be? Well, there are two competing effects at play here. For each little rectangle, let’s call the side along the latitude lines its width, and the side along the longitude lines its height.
+
+On the one hand, as this rectangle is projected outward, its width will get scaled up.
+
+<Figure
+  image="width-scaled-up.png"
+  caption="The projected rectangle is wider than the original."
+/>
+
+For rectangles towards the poles, that width is scaled quite a bit, since they’re projected over a longer distance. For those closer to the equator, less so.
+
+<Figure
+  video="width-variation.mp4"
+  caption="The width difference is more extreme at the poles."
+/>
+
+But on the other hand, because these rectangles are at a slant with respect to the z-direction, during this projection the height of each such rectangle will get scaled down. Think about holding some flat object and looking at its shadow. As you reorient that object, the shadow looks more or less squished for some angles.
+
+<Figure image="slant-shadow.png" video="slant-shadow.mp4" />
+
+Those rectangles towards the poles are quite slanted in this way, so their height gets squished a lot. For those closer to the equator, less so.
+
+<Figure
+  image="height-variation.png"
+  caption="The height difference is also more extreme at the poles."
+/>
+
+It will turn out that these two effects, of stretching the width and squishing the height, cancel each other out perfectly.
+
+As a rough sketch, wouldn’t you agree that this is a very pretty way of reasoning? Of course, the meat here comes from showing why these two competing effects on each rectangle cancel out perfectly. In some ways, the details fleshing this out are just as pretty as the zoomed out structure of the full argument.
+
+### Stretching the width
+For any mathematical problem solving it never hurts to start by giving names to things. So let’s say the radius of the sphere is $R$. Also, focusing on one specific rectangle, let’s call the distance between our rectangle and the z-axis $d$.
+
+<Figure
+  image="R-and-d.png"
+  caption="This cross-section of the sphere shows how we're choosing to label things."
+/>
+
+You could rightfully complain that this distance $d$ is a little ambiguous depending on which point on the rectangle you’re starting from, but for tinier and tinier rectangles that ambiguity will be negligible. And *tinier and tinier* is precisely when this approximation with rectangles gets closer to the true surface area anyway. To choose an arbitrary standard, let’s say $d$ is the distance from the bottom of the rectangle.
+
+To think about projecting out to the cylinder, picture two similar triangles.
+
+<Figure image="similar-triangles.png" />
+
+This first one shares its base with the rectangle on the sphere. The second is a scaled up version of this, scaled so that it just barely reaches the cylinder, meaning its long side now has length $R$. So the ratio of their bases, which is how much our rectangle’s width gets stretched out, is $\frac{R}{d}$.
+
+### Squishing the height
+What about the height? How precisely does that get scaled down as we project?
+
+To figure it out, let's begin by focusing our attention on this 2D cross section:
+
+<Figure image="2d-cross-section.png" video="2d-cross-section.mp4" />
+
+Then, to think about the projection, let’s zoom in and make a little right triangle like this:
+
+<Figure
+  image="right-triangle.png"
+  caption="Our right triangle is positioned with its hypotenuse along the original rectangle, and one of its legs along the projection of that rectangle onto the cylinder."
+/>
+
+**Pro tip:** Any time you’re doing geometry with circles or spheres, keep at the forefront of your mind that anything tangent to the circle is perpendicular to the radius drawn to that point of tangency. It’s crazy how helpful that one little fact can be.
+
+Once we draw that radial line, together with the distance $d$, we have another right triangle.
+
+<Figure image="right-triangle-2.png" />
+
+Often in geometry, I like to imagine tweaking the parameters of a setup and imagining how the relevant shapes change; this helps to make guesses about what relations there are.
+
+In this case, you might predict that the two triangles I’ve drawn are similar to each other, since their shapes change in concert with each other.
+
+<Figure video="tweak-parameters.mp4" />
+
+This is indeed true, but as always, don’t take my word for it, see if you can justify this for yourself.
+
+### Similar triangles
+Again, it never hurts to give more names to things. Let's call these angles $\alpha$ and $\beta$:
+
+<Figure image="alpha-and-beta.png" />
+
+Since this is a right triangle, you know that $\alpha + \beta + 90\degree = 180\degree$. Now zoom in to our little triangle, and see if we can figure out its angles:
+
+<Figure image="small-triangle-angles.png" />
+
+You have $90\degree + \beta + \text{(some angle)}$ forming a straight line. So that little angle must be $\alpha$. This lets us fill in a few more values, revealing that this little triangle has the same angles, $\alpha$ and $\beta$, as the big one.
+
+<Figure image="small-triangle-angles-complete.png" />
+
+So they are indeed similar.
+
+Deep in the weeds, it’s sometimes easy to forget why we’re doing this. We want to know how much the height of our sphere-rectangle gets squished during the projection, which is the ratio of the hypotenuse to the leg on the right. By the similarity with the big triangle, that ratio is $\frac{R}{d}$.
+
+<Figure image="R-over-d.png" />
+
+So indeed, as this rectangle gets projected outward onto the cylinder, the effect of stretching out the width is perfectly canceled out by how much the height gets squished due to the slant.
+
+<Figure image="before-and-after.png" />
+
+<Accordion title="Sidenote: Is that a rotation?">
+
+As a fun sidenote, you might notice that it looks like the projected rectangle is a $90\degree$ rotation of the original. This would *not* be true in general, but by a lovely coincidence, the way I’m parametrizing the sphere results in rectangles where the ratio of the width to the height starts out as $d$ to $R$. So for this very specific case, rescaling the width by $\frac{R}{d}$ and the height by $\frac{d}{R}$ actually does have the same effect as a $90\degree$ rotation.
+
+This lends itself to a rather bizarre way to animate the relation, where instead of projecting each rectangular piece, you rotate each one and rearrange them to make the cylinder.
+
+<Figure video="rotation-animation.mp4" />
+
+</Accordion>
+
+Now, if you’re really thinking critically, you might still not be satisfied that this shows that the surface area of the sphere equals the area of this cylinder label. After all, these little rectangles only *approximate* the relevant areas.
+
+Well, the idea is that this approximation gets closer and closer to the true value for finer and finer coverings. Since for any specific covering, the sphere rectangles have the same area as the cylinder rectangles, whatever values each of these two series of approximations are approaching must actually be the same.
+
+<Figure image="equal-in-limit.png" />
+
+I mean, as you get really aggressively philosophical about what we even mean by surface area, these sorts of rectangular approximations and not just aids in our problem-solving toolbox, they end up serving as a way of rigorously defining the area of smooth curved surfaces.
+
+<Figure image="surface-area-definition.png" />
+
+This kind of reasoning is essentially calculus, just stated without any of the jargon. In fact, I think neat geometric arguments like this, which require no background in calculus to understand, can serve as a great way to tee things up for new calculus students so that they have the core ideas before seeing the definitions which make them precise (rather than the other way around).
+
+<Figure
+  image="preparing-for-calculus.png"
+  caption="These geometric arguments are great preparation for understanding calculus."
+/>
+
+### Connection to circles
+So as I said before, if you’re itching to see a direct connection to four circles, one nice way is to unwrap these circles into triangles. If this is something you haven’t seen before, I go into much more detail about why this works in <LessonLink id="essence-of-calculus">the first lesson of the calculus series</LessonLink>.
+
+The basic idea is to relate thin concentric rings of the circle with horizontal slices of this triangle.
+
+<Figure
+  image="ring-to-slice.png"
+  caption="Each circle is unwrapped such that a thin ring of the circle corresponds to a thin line of the triangle."
+/>
+
+Because the circumference of each such ring increases linearly in proportion to the radius, always equal to $2\pi$ times that radius, when you unwrap them all and line them up, their ends will form a straight line (as opposed to some kind of curvey shape), giving you a triangle with a base of $2\pi r$ and a height of $r$.
+
+And four of these unwrapped circles fit into our rectangle, which is in some sense an unwrapped version of the sphere’s surface.
+
+<Figure image="triangles-fit-rectangle.png" />
+
+## Second approach
+Nevertheless, you might wonder if there’s a way than this to relate the sphere directly to a circle with the same radius, rather than going through this intermediary of the cylinder.
+
+<Figure image="direct-proof.png" />
+
+I do have a proof for you to this effect, leveraging a little trigonometry, though I have to admit I still think the comparison to the cylinder wins out on elegance.
+
+I’m a big believer that the best way to really learn math is to do problems yourself, which is a bit hypocritical coming from a channel essentially consisting of lectures. So I’m going to try something a little different here and present the proof as a heavily guided sequence of exercises. Yes, I know that’s less fun and it means you have to pull out some paper to do some work, but I guarantee you’ll get more out of it this way.
+
+### Solution overview
+At a high level, the approach will be to cut the sphere into many thin rings parallel to the xy-plane.
+
+<Figure image="slice-into-rings.png" />
+
+We will compare the area of these rings to the area of their shadows on the xy-plane.
+
+<Figure
+  image="ring-shadows.png"
+  video="ring-shadows.mp4"
+  caption="The shadows of all the rings in the top hemisphere form a perfect circle."
+/>
+
+All the shadows of the rings from the top hemisphere make up a circle with the same radius as the sphere. The main idea will be to show a correspondence between these ring shadows, and every 2nd ring on the sphere.
+
+<Figure
+  image="every-2nd-ring.png"
+  caption="Here we are looking at every other ring of the sphere. Your goal will be to find a correspondence between the alternating rings shown here and the *shadows* of the top hemisphere rings, shown above."
+/>
+
+Challenge mode here is to stop reading now and try to predict how that might go.
+
+We’ll label each one of these rings based on the angle $\theta$ between the z-axis and a line out to the ring from the sphere’s center.
+
+<Figure
+  image="labelled-with-theta.png"
+  video="labelled-with-theta.mp4"
+  caption="Each ring will be identified by its corresponding angle $\theta$."
+/>
+
+So $\theta$ ranges from 0 to 180 degrees, or $0$ to $\pi$ radians. And let’s call the change in angle from one ring to the next $d \theta$, which means the thickness of one of these rings will be $R \mathop{d\theta}$, where $R$ is the radius of the sphere.
+
+<Figure image="R-d-theta.png" />
+
+Alright, structured exercise time. We’ll ease in with a warm-up.
+
+### Question 1
+What is the circumference of the inner edge of this ring, in terms of $R$ and $\theta$?
+
+<Figure image="question-1.png" />
+
+<FreeResponse>
+
+The circumference of the ring depends on its radius. The ring's radius is the distance from the z-axis to the ring itself, which I'll call lowercase $r$. (Note that we're *not* talking about the radius of the sphere, which we're calling capital $R$.)
+
+$r$ can be found using some trigonometry based on this right triangle:
+
+<Figure image="question-1-diagram.png" />
+
+We know that $\sin(\theta) = \frac{r}{R}$,[^1] which means that $r = R\sin(\theta)$.
+
+And now that we have the radius of the ring, finding its circumference is just a matter of multiplying by $2\pi$.
+
+The circumference, then, is $2\pi R\sin(\theta)$.
+
+</FreeResponse>
+
+Now, go ahead and multiply your answer by the thickness $R \mathop{d\theta}$ to get an approximation for this ring’s area. (This approximation gets better and better as you chop up the sphere more and more finely.)
+
+<Figure image="question-1b.png" />
+
+<FreeResponse>
+
+We found the circumference to be $2\pi R\sin(\theta)$, so multiplying by $R \mathop{d\theta}$ gives an area of approximately $2\pi R^2 \sin(\theta) \mathop{d\theta}$ for the ring at angle $\theta$.
+
+</FreeResponse>
+
+<Accordion title="Bonus challenge: Find the sphere's surface area by integrating">
+
+At this point, if you know your calculus, you could integrate. Finding the surface area of the sphere by integrating is *not* the main point of this exercise, but it can be a fun challenge and a good way to check your answer from part 1.
+
+So, can you find the surface area of the sphere by integrating the ring area formula above?
+
+<FreeResponse>
+
+We are splitting up our sphere into little rings based on the angle $\theta$, where $\theta$ runs from 0 radians (the top ring) to $\pi$ radians (the bottom ring).
+
+So to find the surface area of the sphere, we just add up all the little areas of all the little rings, which&mdash;in the limit&mdash;we represent with the following integral:
+
+$$
+\int_{0}^{\pi} 2\pi R^2 \sin(\theta) \mathop{d\theta}
+$$
+
+From here, it's just a matter of computation:
+
+$$
+\begin{align*}
+=& 2\pi R^2 \int_{0}^{\pi} \sin(\theta) \mathop{d\theta} \\
+=& 2\pi R^2 \left(-\cos(\theta) \Big|_{0}^{\pi} \right) \\
+=& 2\pi R^2 \left(-\cos(\pi) - -\cos(0) \right) \\
+=& 2\pi R^2 \left(1 + 1 \right) \\
+=& 4\pi R^2
+\end{align*}
+$$
+
+That's great! We found the formula for the surface area of a sphere. But our goal is not just to find the answer, it’s to feel the connection between the sphere its shadow. So let's continue.
+
+</FreeResponse>
+
+</Accordion>
+
+### Question 2
+What is the area of the shadow of one of these rings on the xy-plane? Express your answer in terms of $R$, $\theta$ and $\mathop{d \theta}$.
+
+(Hint: Think back to the similar right triangles used in the projection-onto-a-cylinder proof.)
+
+<Figure image="question-2.png" />
+
+<FreeResponse>
+
+Think back to the original projection-onto-a-cylinder proof. Remember how the height of the rectangle got squished as it was projected onto the cylinder, and the amount that it was squished depended on how tilted the rectangle was?
+
+<Figure image="height-squish-review.png" />
+
+It's a very similar story here.
+
+As the ring is projected down onto the xy-plane, its thickness will be squished down, and that squishing will depend on the angle $\theta$. We will set up two similar right triangles, which should feel familiar:
+
+<Figure image="question-2-diagram.png" />
+
+The squishing factor we are trying to find is the ratio of the shadow thickness to the ring thickness. From the perspective of the angle $\theta$ in our little triangle, it's $\frac{\text{Shadow}}{\text{Ring}} = \frac{\text{adjacent}}{\text{hypotenuse}}$, or $\cos(\theta)$.
+
+So the area of the shadow is just the area of the ring times $\cos(\theta)$, or $2\pi R^2 \sin(\theta)\cos(\theta) \mathop{d\theta}$.
+
+</FreeResponse>
+
+### Question 3
+Each of these ring shadows has precisely half the area of one of these rings on the sphere. It’s not the one at angle theta straight above it, but another one. Which one?
+
+<Figure video="which-ring.mp4" loop={true} />
+
+<Accordion title="Hint: A trig identity might help (click to reveal which one)">
+
+$$
+\sin(2\theta) = 2\sin(\theta)\cos(\theta)
+$$
+
+</Accordion>
+
+<FreeResponse>
+
+We determined in question 2 that each ring at angle $\theta$ in the top hemisphere has a shadow of area $2\pi R^2 \sin(\theta)\cos(\theta) \mathop{d\theta}$.
+
+So which ring on this sphere has an area of twice that, $4\pi R^2 \sin(\theta)\cos(\theta) \mathop{d\theta}$?
+
+The original overview of the problem gives a hint that helps eliminate some of the guesswork that might otherwise be involved in trying to find the matching ring:
+
+> "The main idea will be to show a correspondence between these ring shadows [in the top hemisphere], and every 2nd ring on the sphere."
+
+So a reasonable correspondence might be to pair up each ring at $\theta$ with the ring at $2\theta$. That lets us cover alternating rings over the entire sphere, as hinted at above.
+
+So, what is the area of the ring at $2\theta$? Well, we can use our original ring area equation from question 1, but substitute $2\theta$ in place of $\theta$. That gives an area of $2\pi R^2 \sin(2\theta) \mathop{d\theta}$.
+
+We were hoping this would be double the area of the shadow of ring $\theta$, $4\pi R^2 \sin(\theta)\cos(\theta) \mathop{d\theta}$, but it doesn't really appear to be.
+
+This is where a trig identity can save the day:
+
+$$
+\sin(2\theta) = 2\sin(\theta)\cos(\theta)
+$$
+
+Using this substitution, we find that the ring at $2\theta$ has an area of $4\pi R^2 \sin(\theta)\cos(\theta) \mathop{d\theta}$, which is indeed double the area of the shadow of ring $\theta$.
+
+Therefore, the correspondence between ring $\theta$'s shadow and ring $2\theta$ has precisely the property we're looking for.
+
+</FreeResponse>
+
+### Question 4
+I said from the outset that there is a correspondence between all the shadows from the northern hemisphere, which make up a circle with radius $R$, and every other ring on the sphere. Use your answer to the last question to spell out exactly what that correspondence is.
+
+<Figure image="question-4.png" />
+
+<FreeResponse>
+
+Each shadow corresponds to one of the alternating rings of the sphere. The special property of this correspondence, spelled out in question 3, is that corresponding ring has an area double that of the shadow.
+
+This means that the alternating rings have a total area that is exactly double the total area of the shadows.
+
+</FreeResponse>
+
+### Question 5
+Bring it on home. Why does this imply that the area of the circle is exactly ¼ the surface area of the sphere, particularly as we consider thinner and thinner rings?
+
+<Figure image="question-5.png" />
+
+<FreeResponse>
+
+All together, the top-hemisphere ring shadows form a perfect circle of radius $R$ on the xy-plane. This means that the sum of all their areas is exactly $\pi R^2$.
+
+<Figure image="shadows-form-circle.png" video="shadows-form-circle.mp4" />
+
+And because of our special correspondence, we know that the total area of all the alternating rings on the sphere is exactly double the total shadow area. So adding up the areas of these rings of the sphere gives a surface area of $2\pi R^2$:
+
+<Figure
+  image="alternating-rings.png"
+  caption="The total surface area of these rings is $2\pi R^2."
+/>
+
+To get the full sphere surface area for *all* the rings (not just every-other ring), we double our result for an area of $4\pi R^2$.
+
+</FreeResponse>
+
+## The more general shadow formula
+And finally, I’d be remiss not to make a brief mention of the fact that the surface area of a sphere is a specific instance of a much more general fact: If you take any convex shape, and look at the average area of all its shadows, averaged over all possible orientations in 3D space, the surface area of the solid will be precisely 4 times that average shadow area.
+
+<Figure image="average-shadow.png" video="average-shadow.mp4" show="video" />
+
+As to why this is true? I’ll leave those details for another day.
+
+[^1]: Maybe you've seen this as $\sin(\theta) = \frac{\text{opposite}}{\text{hypotenuse}}$.

--- a/public/content/lessons/2018/sphere-area/index.mdx
+++ b/public/content/lessons/2018/sphere-area/index.mdx
@@ -19,7 +19,7 @@ But have you ever wondered *why* is this true? And I don’t just mean proving t
 
 How lovely would it be if there was some shift in perspective that showed how you could nicely and perfectly fit those four circles onto the sphere’s surface?
 
-Nothing can be quite that simple, since the curvature of a sphere’s surface is different from the curvature of a flat plane, which is why trying to fit paper around a sphere doesn’t really work.
+Nothing can be quite that simple, since the [curvature](https://math.stackexchange.com/questions/70210/is-there-any-easy-way-to-understand-the-definition-of-gaussian-curvature) of a sphere’s surface is different from the curvature of a flat plane, which is why trying to fit paper around a sphere doesn’t really work.
 
 <Figure image="paper-circle.png" caption="Good luck." />
 
@@ -96,14 +96,14 @@ It will turn out that these two effects, of stretching the width and squishing t
 As a rough sketch, wouldn’t you agree that this is a very pretty way of reasoning? Of course, the meat here comes from showing why these two competing effects on each rectangle cancel out perfectly. In some ways, the details fleshing this out are just as pretty as the zoomed out structure of the full argument.
 
 ### Stretching the width
-For any mathematical problem solving it never hurts to start by giving names to things. So let’s say the radius of the sphere is $R$. Also, focusing on one specific rectangle, let’s call the distance between our rectangle and the z-axis $d$.
+For any mathematical problem-solving it never hurts to start by giving names to things. Let’s say the radius of the sphere is $R$. Also, focusing on one specific rectangle, let’s call the distance between our rectangle and the z-axis $d$.
 
 <Figure
   image="R-and-d.png"
   caption="This cross-section of the sphere shows how we're choosing to label things."
 />
 
-You could rightfully complain that this distance $d$ is a little ambiguous depending on which point on the rectangle you’re starting from, but for tinier and tinier rectangles that ambiguity will be negligible. And *tinier and tinier* is precisely when this approximation with rectangles gets closer to the true surface area anyway. To choose an arbitrary standard, let’s say $d$ is the distance from the bottom of the rectangle.
+You could rightfully complain that this distance $d$ is a little ambiguous depending on which point on the rectangle you’re starting from, but for tinier and tinier rectangles that ambiguity will be negligible. And *tinier and tinier* is precisely when this approximation with rectangles gets closer to the true surface area anyway. To choose an arbitrary standard, let’s say $d$ is the distance from the bottom of the rectangle to the z-axis.
 
 To think about projecting out to the cylinder, picture two similar triangles.
 
@@ -174,11 +174,11 @@ This lends itself to a rather bizarre way to animate the relation, where instead
 
 Now, if you’re really thinking critically, you might still not be satisfied that this shows that the surface area of the sphere equals the area of this cylinder label. After all, these little rectangles only *approximate* the relevant areas.
 
-Well, the idea is that this approximation gets closer and closer to the true value for finer and finer coverings. Since for any specific covering, the sphere rectangles have the same area as the cylinder rectangles, whatever values each of these two series of approximations are approaching must actually be the same.
+The idea is that this approximation gets closer and closer to the true value for finer and finer coverings. Since for any specific covering, the sphere rectangles have the same area as the cylinder rectangles, whatever values each of these two series of approximations are approaching must actually be the same.
 
 <Figure image="equal-in-limit.png" />
 
-I mean, as you get really aggressively philosophical about what we even mean by surface area, these sorts of rectangular approximations and not just aids in our problem-solving toolbox, they end up serving as a way of rigorously defining the area of smooth curved surfaces.
+As you get more philosophical and ask what exactly we mean by surface area, these sorts of rectangular approximations and not just aids in our problem-solving toolbox, they end up serving as a way of rigorously defining the area of smooth curved surfaces, though often [some care is required](https://en.wikipedia.org/wiki/Schwarz_lantern).
 
 <Figure image="surface-area-definition.png" />
 
@@ -190,7 +190,7 @@ This kind of reasoning is essentially calculus, just stated without any of the j
 />
 
 ### Connection to circles
-So as I said before, if you’re itching to see a direct connection to four circles, one nice way is to unwrap these circles into triangles. If this is something you haven’t seen before, I go into much more detail about why this works in <LessonLink id="essence-of-calculus">the first lesson of the calculus series</LessonLink>.
+If you’re itching to see a direct connection to four circles, one nice way is to unwrap these circles into triangles. If this is something you haven’t seen before, I go into much more detail about why this works in <LessonLink id="essence-of-calculus">the first lesson of the calculus series</LessonLink>.
 
 The basic idea is to relate thin concentric rings of the circle with horizontal slices of this triangle.
 
@@ -206,13 +206,13 @@ And four of these unwrapped circles fit into our rectangle, which is in some sen
 <Figure image="triangles-fit-rectangle.png" />
 
 ## Second approach
-Nevertheless, you might wonder if there’s a way than this to relate the sphere directly to a circle with the same radius, rather than going through this intermediary of the cylinder.
+Nevertheless, you might wonder if there’s a way to relate the sphere directly to a circle with the same radius, rather than going through this intermediary of the cylinder.
 
 <Figure image="direct-proof.png" />
 
-I do have a proof for you to this effect, leveraging a little trigonometry, though I have to admit I still think the comparison to the cylinder wins out on elegance.
+If you're willing to roll up your sleeves and leverage a little trigonometry, it is actually possible to draw this more direct connection.
 
-I’m a big believer that the best way to really learn math is to do problems yourself, which is a bit hypocritical coming from a channel essentially consisting of lectures. So I’m going to try something a little different here and present the proof as a heavily guided sequence of exercises. Yes, I know that’s less fun and it means you have to pull out some paper to do some work, but I guarantee you’ll get more out of it this way.
+I’m a big believer that the best way to really learn math is to do problems yourself, which is a bit hypocritical coming from a channel essentially consisting of lectures. So let's try something a little different here and present the proof as a heavily guided sequence of exercises. Yes, I know that’s less fun and it means you have to pull out some paper to do some work, but I guarantee you’ll get more out of it this way.
 
 ### Solution overview
 At a high level, the approach will be to cut the sphere into many thin rings parallel to the xy-plane.
@@ -412,7 +412,7 @@ And because of our special correspondence, we know that the total area of all th
   caption="The total surface area of these rings is $2\pi R^2."
 />
 
-To get the full sphere surface area for *all* the rings (not just every-other ring), we double our result for an area of $4\pi R^2$.
+In the limit as these rings get ever thinner, the area of the alternating rings approaches half the total surface area. This is because each ring has approximately the same area as its immediate neighbors in that limiting case, so for example the sum of the areas of all the odd-numbered rings will equal the sum of the areas of the even-numbered rings. So to get the full surface area of the sphere, we double the total area of the alternating rings, which is $4\pi R^2$.
 
 </FreeResponse>
 
@@ -423,4 +423,4 @@ And finally, I’d be remiss not to make a brief mention of the fact that the su
 
 As to why this is true? I’ll leave those details for another day.
 
-[^1]: Maybe you've seen this as $\sin(\theta) = \frac{\text{opposite}}{\text{hypotenuse}}$.
+[^1]: $\sin(\theta) = \frac{\text{opposite}}{\text{hypotenuse}}$.

--- a/public/content/lessons/2018/sphere-area/label-of-cylinder.png
+++ b/public/content/lessons/2018/sphere-area/label-of-cylinder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5001536df7219d93958654f84bdffdab9cfde9eabcb82912f365ab7e18ca6617
+size 1149187

--- a/public/content/lessons/2018/sphere-area/labelled-with-theta.mp4
+++ b/public/content/lessons/2018/sphere-area/labelled-with-theta.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb6ed1dcbbebff3ae91024e3c7c832ef963d6206636de9847d156c81226720fc
+size 578466

--- a/public/content/lessons/2018/sphere-area/labelled-with-theta.png
+++ b/public/content/lessons/2018/sphere-area/labelled-with-theta.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:064ea87511aec68a5436d46cafd94b25138923011c6932219775b74c3a2c1ebe
+size 715109

--- a/public/content/lessons/2018/sphere-area/paper-circle.png
+++ b/public/content/lessons/2018/sphere-area/paper-circle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c9404fce6d87e8476a4d53ebd3ec8a8fabe3254678c4d7f98863e9097e1e6c8
+size 1586666

--- a/public/content/lessons/2018/sphere-area/preparing-for-calculus.png
+++ b/public/content/lessons/2018/sphere-area/preparing-for-calculus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1121b6c6d37b29aa4152e70576f2c48c60f431923004a9e1146b658589c9afb7
+size 770172

--- a/public/content/lessons/2018/sphere-area/projection-equal.png
+++ b/public/content/lessons/2018/sphere-area/projection-equal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cb0ab3bfe107d9c15dada201a7ee4352367ddae24057a15b2e6e71d5aaaac44
+size 996252

--- a/public/content/lessons/2018/sphere-area/question-1-diagram.png
+++ b/public/content/lessons/2018/sphere-area/question-1-diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22f90d07b6f097cc67e6659d6a48e9e6639b39d0516258502c99982a6e1bb1be
+size 359365

--- a/public/content/lessons/2018/sphere-area/question-1.png
+++ b/public/content/lessons/2018/sphere-area/question-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d45683aeebe9f84e90cecbb742f7dc21057499ad9701d4eddfae308e00382321
+size 964106

--- a/public/content/lessons/2018/sphere-area/question-1b.png
+++ b/public/content/lessons/2018/sphere-area/question-1b.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0354117ee9e74259364b6291fef5ea79fa24bf2c3bec664f8019994c46ce0bd8
+size 938388

--- a/public/content/lessons/2018/sphere-area/question-2-diagram.png
+++ b/public/content/lessons/2018/sphere-area/question-2-diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60bc90b8177fe16e8e92dd82ab92cb81d6a6fb160c728fa8deb69aaec8e04280
+size 378433

--- a/public/content/lessons/2018/sphere-area/question-2.png
+++ b/public/content/lessons/2018/sphere-area/question-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a857b7645c70a55c21d20df8adbdc07bd8ff33af56f0561f3796fec3ecdaa002
+size 1020246

--- a/public/content/lessons/2018/sphere-area/question-4.png
+++ b/public/content/lessons/2018/sphere-area/question-4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9b98cffe08b307c3232c1934bd242a7a4e339093139b729f330bca19b91e793
+size 961413

--- a/public/content/lessons/2018/sphere-area/question-5.png
+++ b/public/content/lessons/2018/sphere-area/question-5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0ef4c76b2b4bbe91f6f04e12de3c934b8b4cf957dc41e1d37e2753159d2f72a
+size 901732

--- a/public/content/lessons/2018/sphere-area/rectangle-dimensions.png
+++ b/public/content/lessons/2018/sphere-area/rectangle-dimensions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e0d9b4d814e7f65fa101ef53c6fc694be6a46df5dd6d11c6a80556e3d7450d2
+size 1104497

--- a/public/content/lessons/2018/sphere-area/rectangle.png
+++ b/public/content/lessons/2018/sphere-area/rectangle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c3dc4ea3de7b3b720893e571f6257702cdc0e5183ad64630431ee3394a17bd0
+size 1099610

--- a/public/content/lessons/2018/sphere-area/right-triangle-2.png
+++ b/public/content/lessons/2018/sphere-area/right-triangle-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ad02c9993b28d3a733a3013f006846cb9d25d5ef279abe2e7a9b43d74702300
+size 240454

--- a/public/content/lessons/2018/sphere-area/right-triangle.png
+++ b/public/content/lessons/2018/sphere-area/right-triangle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f167c6c7490e4de37455c2a860d1591f308b72b41afa0edb39759ad43c62ef0
+size 226830

--- a/public/content/lessons/2018/sphere-area/ring-shadows.mp4
+++ b/public/content/lessons/2018/sphere-area/ring-shadows.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b565dbde1764cc29013665796d975f50b214bc75eeaa1270ce1f979cd5f00d64
+size 1184384

--- a/public/content/lessons/2018/sphere-area/ring-shadows.png
+++ b/public/content/lessons/2018/sphere-area/ring-shadows.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d036ef40f19ac6b8b1225276cfa254e60a6a852c54fbc8931adfc19eca95fc3
+size 812974

--- a/public/content/lessons/2018/sphere-area/ring-to-slice.png
+++ b/public/content/lessons/2018/sphere-area/ring-to-slice.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9006d85b29f19f4ddef07c8822bc890ee32d19caede9b3258a1be66d93284f6
+size 94132

--- a/public/content/lessons/2018/sphere-area/rotation-animation.mp4
+++ b/public/content/lessons/2018/sphere-area/rotation-animation.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bc22872ce68a7960ad9d549e0c9db0dd78928925fdb77b45bcc6374a9e1d1da
+size 6902391

--- a/public/content/lessons/2018/sphere-area/shadows-form-circle.mp4
+++ b/public/content/lessons/2018/sphere-area/shadows-form-circle.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8508592484c5d3ded800c17359ee26f35f5e09e388c6093e9baa8c14899789b
+size 1081575

--- a/public/content/lessons/2018/sphere-area/shadows-form-circle.png
+++ b/public/content/lessons/2018/sphere-area/shadows-form-circle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8ff4d5bc324a693e68523b7cb79aaee0ad7efb96dc0829c2a827eb9e377894
+size 578880

--- a/public/content/lessons/2018/sphere-area/similar-triangles.png
+++ b/public/content/lessons/2018/sphere-area/similar-triangles.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45ae13fd14fba99238d320db5ec88910feff2d57c14953a5202406bc9bfd1471
+size 1058800

--- a/public/content/lessons/2018/sphere-area/slant-shadow.mp4
+++ b/public/content/lessons/2018/sphere-area/slant-shadow.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58552d3c9b558e2a0de7d32f519f9d8a146ec6c56ca4ea40493ed2b67e8abf63
+size 2673451

--- a/public/content/lessons/2018/sphere-area/slant-shadow.png
+++ b/public/content/lessons/2018/sphere-area/slant-shadow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bac4d6e6e3a1643610b236f46b027e0dce0c9376780c404f09d1e2720ac0514
+size 1126712

--- a/public/content/lessons/2018/sphere-area/slice-into-rings.png
+++ b/public/content/lessons/2018/sphere-area/slice-into-rings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f6e06e87ae01afcbee30b177a637ae4fb866ed50c2847021b764873f36d967f
+size 514326

--- a/public/content/lessons/2018/sphere-area/small-triangle-angles-complete.png
+++ b/public/content/lessons/2018/sphere-area/small-triangle-angles-complete.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1531cc3e8869a73c0d99a3e798f1c69abb6f7989d47f8ff50ffbc7f443f40583
+size 469960

--- a/public/content/lessons/2018/sphere-area/small-triangle-angles.png
+++ b/public/content/lessons/2018/sphere-area/small-triangle-angles.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7131e14dce983cc5433efda19b205f09cbc4d209727e60f45804defffbf5cce7
+size 479643

--- a/public/content/lessons/2018/sphere-area/sphere-equals-cylinder.png
+++ b/public/content/lessons/2018/sphere-area/sphere-equals-cylinder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac7d5d6391e930b50b9769f636ed2805d6cefb4e73ec1d28b33d787dfaf6cb2a
+size 1244095

--- a/public/content/lessons/2018/sphere-area/sphere-to-cylinder.mp4
+++ b/public/content/lessons/2018/sphere-area/sphere-to-cylinder.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d09a0feb166a89e1e35a2265ede65b07e80af4fe8e80bb8a12737cef729f5e0
+size 2656025

--- a/public/content/lessons/2018/sphere-area/sphere-vs-circles.png
+++ b/public/content/lessons/2018/sphere-area/sphere-vs-circles.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2cb92c162d9e25b70b6a4d92a114aeb251cabdec348972bbefb662c8845a08e
+size 1106420

--- a/public/content/lessons/2018/sphere-area/surface-area-definition.png
+++ b/public/content/lessons/2018/sphere-area/surface-area-definition.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c98f8a792e043ee0877db803c514383e694976cef2d3344c9e90d1c039605423
+size 1169535

--- a/public/content/lessons/2018/sphere-area/triangles-fit-rectangle.png
+++ b/public/content/lessons/2018/sphere-area/triangles-fit-rectangle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b2ba85428bb5d82d6f807122c2d935c174f79ad156fc5bef6bc6eaacd1c6a1f
+size 95992

--- a/public/content/lessons/2018/sphere-area/tweak-parameters.mp4
+++ b/public/content/lessons/2018/sphere-area/tweak-parameters.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ab499e1c2a5aca0de2995ff4c11e7608e230325edfcf2062bd56e8f5c003e9b
+size 468040

--- a/public/content/lessons/2018/sphere-area/two-proofs.png
+++ b/public/content/lessons/2018/sphere-area/two-proofs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4175d0b7a7ecc9e024626555cbbb7bb6222cb484ee75c026bd7bde42102864b1
+size 503376

--- a/public/content/lessons/2018/sphere-area/unwrap-cylinder.mp4
+++ b/public/content/lessons/2018/sphere-area/unwrap-cylinder.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b152cb72c48e5740def03821985c903ab0abbb1e3664986be2543ff709eae80
+size 3103259

--- a/public/content/lessons/2018/sphere-area/which-ring.mp4
+++ b/public/content/lessons/2018/sphere-area/which-ring.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e01bd8cf37c25dbec9ee4057649d5a6140f1ff4e0e21dbf0ebfa42addbe1c86f
+size 411644

--- a/public/content/lessons/2018/sphere-area/width-scaled-up.png
+++ b/public/content/lessons/2018/sphere-area/width-scaled-up.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c75b8915694355fd0994a35459ae5d2a380ce8a26e800611c2f211f01b16e570
+size 786645

--- a/public/content/lessons/2018/sphere-area/width-variation.mp4
+++ b/public/content/lessons/2018/sphere-area/width-variation.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7ec3020adc5c8b22c7d0c445ee8cca3f17e5070465932024d34aa7353d2d4a6
+size 1570785


### PR DESCRIPTION
Lesson authoring peer review checklist:
- [x] Includes authorship line: `Text adaptation by [Name]`
- [x] The lesson has an informative/compelling description, fit for a preview on the home page.
- [x] The lesson has no grammar/spelling errors
- [x] The lesson has no mathematical errors
- [x] The table of contents effectively conveys the overall structure of the lesson
- [x] The lesson uses no `# Top Level` headings
- [x] The lesson includes well-chosen comprehension questions
- [x] The lesson incorporates the core visuals from the video
- [x] The visuals are clear and helpful for understanding
- [x] The components are used in the places and ways they are intended (see the readme)

This pull request:
- Creates lesson `sphere-area`
- Slightly modifies the free response component to blur images and videos more aggressively than text, to avoid any spoilers