### PR TITLE
Improve search result order of lessons in a series

### DIFF
--- a/components/LessonGallery/index.js
+++ b/components/LessonGallery/index.js
@@ -28,7 +28,21 @@ export default function LessonGallery({ show = "topic" }) {
       return lessons;
     }
 
-    return lessons.filter((lesson) => matchesSearch(lesson, searchText));
+    return lessons
+      .filter((lesson) => matchesSearch(lesson, searchText))
+      .sort((a, b) => {
+        if (a.topic === b.topic) {
+          if (typeof a.chapter === "number") {
+            const topic = topics.find((t) => t.name === a.topic);
+            if (!topic) return 0;
+            return (
+              topic.lessons.indexOf(a.slug) - topic.lessons.indexOf(b.slug)
+            );
+          }
+        }
+
+        return new Date(b.date) - new Date(a.date);
+      });
   }, [lessons, view, searchText]);
 
   const googleURL = new URL("https://google.com/search");

--- a/public/content/lessons/2017/backpropagation-calculus/index.mdx
+++ b/public/content/lessons/2017/backpropagation-calculus/index.mdx
@@ -2,6 +2,7 @@
 title: Backpropagation calculus
 description: The math of backpropagation, the algorithm by which neural networks learn.
 date: 2017-11-03
+chapter: 5
 video: tIeHLnjs5U8
 source: _2017/nn/part3.py
 credits:

--- a/public/content/lessons/2017/backpropagation/index.mdx
+++ b/public/content/lessons/2017/backpropagation/index.mdx
@@ -2,6 +2,7 @@
 title: What is backpropagation really doing?
 description: An overview of backpropagation, the algorithm behind how neural networks learn.
 date: 2017-11-03
+chapter: 4
 video: Ilg3gGewQ5U
 source: _2017/nn/part3.py
 credits:

--- a/public/content/lessons/2017/gradient-descent/index.mdx
+++ b/public/content/lessons/2017/gradient-descent/index.mdx
@@ -2,6 +2,7 @@
 title: Gradient descent, how neural networks learn
 description: An overview of gradient descent in the context of neural networks. This is a method used widely throughout machine learning for optimizing how a computer performs on certain tasks.
 date: 2017-10-16
+chapter: 2
 video: IHZwWFHWa-w
 source: _2017/nn/part2.py
 credits:

--- a/public/content/lessons/2017/neural-network-analysis/index.mdx
+++ b/public/content/lessons/2017/neural-network-analysis/index.mdx
@@ -2,6 +2,7 @@
 title: Analyzing our neural network
 # description: 
 date: 2017-10-16
+chapter: 3
 credits:
   - Lesson by Grant Sanderson
   - Text adaptation by Josh Pullen

--- a/public/content/lessons/2017/neural-networks/index.mdx
+++ b/public/content/lessons/2017/neural-networks/index.mdx
@@ -2,6 +2,7 @@
 title: But what is a Neural Network?
 description: An overview of what a neural network is, introduced in the context of recognizing hand-written digits.
 date: 2017-10-05
+chapter: 1
 video: aircAruvnKk
 source: _2017/nn/part1.py
 credits:


### PR DESCRIPTION
Website change review checklist:
- [x] I have requested a review from the appropriate persons
- [x] I have checked that my changes work in the preview
- [x] I have checked that the rest of the site is still functioning in the preview
- [x] I have checked that my content/code is consistent with existing content/code
- [x] I have used components in the places and ways they are intended (see the readme)
- [x] I have formatted all of my code with Prettier

This pull request:
- Slightly tweaks the search result ordering so that most results are reverse-chronological, but lessons in a series try their best to appear in a reasonable order, with probably an 85% success rate
- Makes neural networks a series with chapter numbers (rather than just a topic)
- Closes #189