### PR TITLE
Fix typo (copy-paste error?) in last question

### DIFF
--- a/public/content/lessons/2019/windmills/index.mdx
+++ b/public/content/lessons/2019/windmills/index.mdx
@@ -174,13 +174,13 @@ If there are an even number of points, we need to alter the scheme slightly, but
 The same argument applies that after a $180^\circ$ turn, all the points will have swapped color, although this time the line might be passing through a different point after that first half turn, specifically one that used to be blue. 
 
 <Question 
-    question="After a $180^\circ$ turn, will the line be passing through the same point it started on?"
+    question="After a $360^\circ$ turn, will the line be passing through the same point it started on?"
     choice1="Yes"
     choice2="No"
     answer={1}
 >
 
-After a $180^\circ$ turn, the line must be parallel to its starting position, and if it was passing through any other point, the number of points on a given side would be different. This would break insight #1. 
+After a $360^\circ$ turn, the line must be parallel to its starting position, and if it was passing through any other point, the number of points on a given side would be different. This would break insight #1. 
 
 </Question>
 


### PR DESCRIPTION
In the case of an even number of points, after a 180° turn, the pivot point must be the one to the right of the initial pivot, else the number of blue vs brown points would have changed: the initial pivot would still be brown, but every other point changed color.
Since we had one less brown non-pivot point, we'd have one less blue non-pivot point now, so two more blue than brown points. 
If we're considering 360° instead, then we should be fine, since whatever was left of the line initially is left again, same for right.

<!-- Use this checklist if you're authoring a lesson -->

Lesson authoring peer review checklist:

- [ ] Includes authorship line: `Text adaptation by [Name]`
- [ ] The lesson has an informative/compelling description, fit for a preview on the home page.
- [ ] The lesson has no grammar/spelling errors
- [ ] The lesson has no mathematical errors
- [ ] The table of contents effectively conveys the overall structure of the lesson
- [ ] The lesson uses no `# Top Level` headings
- [ ] The lesson includes well-chosen comprehension questions
- [ ] The lesson incorporates the core visuals from the video
- [ ] The visuals are clear and helpful for understanding
- [ ] The components are used in the places and ways they are intended (see the readme)

<!-- Use this checklist if you're making any other changes to the website -->

Website change review checklist:

- [ ] I have requested a review from the appropriate persons
- [ ] I have checked that my changes work in the preview
- [ ] I have checked that the rest of the site is still functioning in the preview
- [ ] I have checked that my content/code is consistent with existing content/code
- [ ] I have used components in the places and ways they are intended (see the readme)
- [ ] I have formatted all of my code with Prettier

<!-- List what this pull request adds/changes/removes/fixes. Paste into message box when you squash merge. -->

This pull request:

-
-
-
