### PR TITLE
Opt out of FLoC

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,8 @@
 
 [context.deploy-preview]
   command = "yarn build"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Permissions-Policy = "interest-cohort=()"


### PR DESCRIPTION
This pull request:

- Alters netlify.toml to opt out of FLoC (more can be read about it here: https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea)