### PR TITLE
Fix small typo in Essence of Calculus Ch.1

### DIFF
--- a/public/content/lessons/2017/essence-of-calculus/index.mdx
+++ b/public/content/lessons/2017/essence-of-calculus/index.mdx
@@ -285,7 +285,7 @@ This says the ratio of a tiny change in $A$ to the tiny change in $x$ that cause
  image="figure-13.08.png" 
 />
 
-For example, think about two nearby inputs, like $3$ and $3.001$.  The change to $x$, then, is $dx = 0.001$.  The change $dA$ would be the difference between the mystery function evaluated at $3.001$ and evaluated $3$.  Even though we don’t know what that mystery function is, we do know something about this change<!--TODO: Reference formula number from above here-->, namely that this change divided by $dx = 0.001$ is approximately $3^2$.
+For example, think about two nearby inputs, like $3$ and $3.001$.  The change to $x$, then, is $dx = 0.001$.  The change $dA$ would be the difference between the mystery function evaluated at $3.001$ and evaluated at $3$.  Even though we don’t know what that mystery function is, we do know something about this change<!--TODO: Reference formula number from above here-->, namely that this change divided by $dx = 0.001$ is approximately $3^2$.
 
 $$
 \frac{A(3.001)-A(3)}{0.001} \approx 3^{2}


### PR DESCRIPTION
This pull request:
- fixes a small typo in Essence of Calculus Ch.1: 
    "function evaluated at 3.001 and evaluated 3" ->
    "function evaluated at 3.001 and evaluated *at* 3"
