### PR TITLE
Fix typo in inverse-matrices lesson

### DIFF
--- a/public/content/lessons/2016/inverse-matrices/index.mdx
+++ b/public/content/lessons/2016/inverse-matrices/index.mdx
@@ -37,9 +37,9 @@ _{\large\text{Equations}}
 \end{matrix}
 \end{matrix}
 $$
-These variables could be voltages across various elements in a circuit, prices of certain stocks, parameters in a machine learning network, really any situation where you might be dealing with multiple unknown numbers that somehow depend on one and other.
+These variables could be voltages across various elements in a circuit, prices of certain stocks, parameters in a machine learning network, really any situation where you might be dealing with multiple unknown numbers that somehow depend on one another.
 
-How exactly they depend on each other is determined by the substance of your science, whether that means modeling the physics of circuits, the dynamics of the economy, or interactions in a neural network, but often you end up with a list of equations which relate these variables to one and other. In many situations, these equations can get *very* complicated.
+How exactly they depend on each other is determined by the substance of your science, whether that means modeling the physics of circuits, the dynamics of the economy, or interactions in a neural network, but often you end up with a list of equations which relate these variables to one another. In many situations, these equations can get *very* complicated.
 $$
 \begin{align*}
 \frac1{1-e^{2x-3y+4z}}&=1 \\


### PR DESCRIPTION
- There were two cases of "one another" being written as "one and other".

Website change review checklist:

- [ ] I have requested a review from the appropriate persons
- [x] I have checked that my changes work in the preview (Did not run the preview due to it only being text changes)
- [x] I have checked that the rest of the site is still functioning in the preview (Did not run the preview due to it only being text changes)
- [x] I have checked that my content/code is consistent with existing content/code
- [x] I have used components in the places and ways they are intended (see the readme) (No new components introduces)
- [x] I have formatted all of my code with Prettier (No actual code changes introduced, I have not run prettier over the existing code) 

This pull request:
- Fixes two minor errors where "one another" was instead written as "one and other". 

In the following two paragraphs: 

> These variables could be voltages across various elements in a circuit, prices of certain stocks, parameters in a machine learning network, really any situation where you might be dealing with multiple unknown numbers that somehow depend on ~**one and other**~ one another.

> How exactly they depend on each other is determined by the substance of your science, whether that means modeling the physics of circuits, the dynamics of the economy, or interactions in a neural network, but often you end up with a list of equations which relate these variables to ~**one and other**~ one another. In many situations, these equations can get very complicated.
