### PR TITLE
Adds default behavior to the HomepageFeaturedContent component

### DIFF
--- a/components/HomepageFeaturedContent/index.js
+++ b/components/HomepageFeaturedContent/index.js
@@ -15,6 +15,7 @@ import Markdownify from "../Markdownify";
 import Link from "next/link";
 import styles from "./index.module.scss";
 import { transformSrc } from "../../util/transformSrc";
+import { PageContext } from "../../pages/_app";
 
 HomepageFeaturedContent.propTypes = {
   title: PropTypes.string.isRequired,
@@ -47,9 +48,18 @@ HomepageFeaturedItem.propTypes = {
 };
 
 export function HomepageFeaturedItem({ lesson, caption, children, link="" }) {
+  
   if(link == ""){
     link = `/lessons/${lesson}`
   }
+
+  // Get the youtubeId of the featured lesson. Needs to check if the lesson is
+  // undefined because of the pi-comment that has an empty lesson string provided.
+  let youtubeId;
+  const { lessons = [] } = useContext(PageContext);
+  const ctx = lessons.find((ctx) => ctx.slug === lesson);
+  if (ctx) { youtubeId = ctx.video }
+
   return (
     <FeaturedItemContext.Provider value={{ lesson }}>
       <div>
@@ -67,7 +77,7 @@ export function HomepageFeaturedItem({ lesson, caption, children, link="" }) {
         </div>}
 
         <figure className={styles.itemFigure}>
-          {children}
+          {children || <img src={`https://img.youtube.com/vi/${youtubeId}/maxresdefault.jpg`} />}
           <figcaption className={styles.itemCaption}>
             <Link href={link}>
               <a>{caption}</a>

--- a/public/content/index.mdx
+++ b/public/content/index.mdx
@@ -4,7 +4,6 @@
     subtitle="3Blue1Brown is mainly a [YouTube channel](https://www.youtube.com/3blue1brown), but here you can find written and interactive adaptations of the lessons."
     >
     <HomepageFeaturedItem lesson="visual-proofs" caption="Latest video: How to Lie with Visual Proofs">
-      <img src="https://img.youtube.com/vi/VYQVlVoWoPY/maxresdefault.jpg" />
     </HomepageFeaturedItem>
     <HomepageFeaturedItem lesson="neural-networks" caption="Learn how neural networks work">
       <Interactive filename="lessons/2017/neural-networks/neural-network-interactive/index" />


### PR DESCRIPTION
This pull request:

- Makes it so that the HomepageFeaturedContent component uses the thumbnail uploaded to Youtube when no children are provided
- Closes #308 

For example, when a new video is published, the following component can be quickly added to the site that pulls the video's thumbnail from youtube. Of course, a video or interactive could be added later to replace the static image.

```html
<HomepageFeaturedItem lesson="visual-proofs" caption="Latest video: How to Lie with Visual Proofs">
</HomepageFeaturedItem>
```