### PR TITLE
Fixed Typo

### DIFF
--- a/public/content/lessons/2019/windmills/index.mdx
+++ b/public/content/lessons/2019/windmills/index.mdx
@@ -159,7 +159,7 @@ Great, that’s insight #1. Now why would this imply that the line must hit ever
     answer={1}
 >
 
-Since the line has rotated halfway around, every point which was initially to the line's left, and so was colored blue, is no to the line's right, and so is colored brown. Likewise, every point which began brown becomes blue. The only way to change color is if you get hit by the line.
+Since the line has rotated halfway around, every point which was initially to the line's left, and so was colored blue, is now to the line's right, and so is colored brown. Likewise, every point which began brown becomes blue. The only way to change color is if you get hit by the line.
 
 </Question>
 


### PR DESCRIPTION
Fixed Typo. Changed no to now in quiz.

<!-- Use this checklist if you're authoring a lesson -->

Lesson authoring peer review checklist:

- [x] Includes authorship line: `Text adaptation by [Name]`
- [x] The lesson has an informative/compelling description, fit for a preview on the home page.
- [x] The lesson has no grammar/spelling errors
- [x] The lesson has no mathematical errors
- [x] The table of contents effectively conveys the overall structure of the lesson
- [x] The lesson uses no `# Top Level` headings
- [x] The lesson includes well-chosen comprehension questions
- [x] The lesson incorporates the core visuals from the video
- [x] The visuals are clear and helpful for understanding
- [x] The components are used in the places and ways they are intended (see the readme)

<!-- Use this checklist if you're making any other changes to the website -->

Website change review checklist:

- [x] I have requested a review from the appropriate persons
- [x] I have checked that my changes work in the preview
- [x] I have checked that the rest of the site is still functioning in the preview
- [x] I have checked that my content/code is consistent with existing content/code
- [x] I have used components in the places and ways they are intended (see the readme)
- [x] I have formatted all of my code with Prettier

<!-- List what this pull request adds/changes/removes/fixes. Paste into message box when you squash merge. -->

This pull request:

-changes  public/content/lessons/2019/windmills/index.mdx
-fixed typo 'no' to 'now' in quiz
