### PR TITLE
fix capitalization of GitHub

### DIFF
--- a/layouts/LessonLayout.js
+++ b/layouts/LessonLayout.js
@@ -54,7 +54,7 @@ const CorrectionLink = () => {
     <div style={{ marginTop: 24 }}>
       Notice a mistake?{" "}
       <a href={url} target="_blank" rel="noreferrer">
-        Submit a correction on Github
+        Submit a correction on GitHub
       </a>
     </div>
   );


### PR DESCRIPTION
Website change review checklist:

- [ ] I have requested a review from the appropriate persons
- [ ] I have checked that my changes work in the preview
- [ ] I have checked that the rest of the site is still functioning in the preview
- [ ] I have checked that my content/code is consistent with existing content/code
- [ ] I have used components in the places and ways they are intended (see the readme)
- [ ] I have formatted all of my code with Prettier

This pull request:

- fixes the capitalization of "GitHub"
