### PR TITLE
Gradient Descent lesson: fix weight nudge video link

### DIFF
--- a/public/content/lessons/2017/gradient-descent/index.mdx
+++ b/public/content/lessons/2017/gradient-descent/index.mdx
@@ -249,7 +249,7 @@ Imagine organizing all the weights and biases for the entire network into one bi
 
 <Figure
   image="weights-and-gradient.png"
-  video="gradient-nudge-weights .mp4"
+  video="gradient-nudge-weights.mp4"
   caption="The vector on the left is a list of all the weights and biases for the entire network. The vector on the right is the negative gradient, which is just a list of all the little nudges you should make to the weights and biases (on the left) in order to move downhill."
 />
 


### PR DESCRIPTION
This pull request fixes a typo in one of the Figures in gradient-descent/index.mdx, which currently prevents the gradient-nudge-weights.mp4 video from playing on https://www.3blue1brown.com/lessons/gradient-descent.