### PR TITLE
add localdate to account for utc offset in publishing dates

### DIFF
--- a/util/locale.js
+++ b/util/locale.js
@@ -1,12 +1,16 @@
 // format date to string in appropriate locale
 export const formatDate = (dateString) => {
+  const localDate = new Date(
+    new Date(dateString).getTime() + new Date().getTimezoneOffset() * 60000
+  );
+
   try {
     let locale;
     if (typeof window !== "undefined") locale = window?.navigator?.language;
     else locale = "en-US";
     const options = { day: "numeric", month: "short", year: "numeric" };
-    return new Date(dateString).toLocaleDateString(locale, options);
+    return new Date(localDate).toLocaleDateString(locale, options);
   } catch (error) {
-    return new Date(dateString).toLocaleDateString();
+    return new Date(localDate).toLocaleDateString();
   }
 };


### PR DESCRIPTION
Website change review checklist:

- [x] I have requested a review from the appropriate persons
- [x] I have checked that my changes work in the preview
- [x] I have checked that the rest of the site is still functioning in the preview
- [x] I have checked that my content/code is consistent with existing content/code
- [x] I have used components in the places and ways they are intended (see the readme)
- [x] I have formatted all of my code with Prettier

<!-- List what this pull request adds/changes/removes/fixes. Paste into message box when you squash merge. -->

This pull request:

- Fixes #306 
- There was a off by 1 error happening with publishing dates across all lessons due to the UTC vs local timezone formatting
- Now the date posted in the public folder matches the date on the website

<img width="700" alt="image" src="https://github.com/3b1b/3Blue1Brown.com/assets/36285610/b84a227a-197a-4ef0-9c45-309a430396e8">
<img width="672" alt="image" src="https://github.com/3b1b/3Blue1Brown.com/assets/36285610/7e265f44-3798-4ad8-a9c7-6b406ef302e5">
