### PR TITLE
Display Images In Production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,9 @@ config = {
 
 config = {
   ...config,
+  images: {
+    path: "",
+  },
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,


### PR DESCRIPTION
- [x] I have requested a review from the appropriate persons
- [x] I have checked that my changes work in the preview
- [x] I have checked that the rest of the site is still functioning in the preview
- [x] I have checked that my content/code is consistent with existing content/code
- [x] I have used components in the places and ways they are intended (see the readme)
- [x] I have formatted all of my code with Prettier

- Fixes #367 
- adds an images field in the config with an empty path to allow for relative images to pull from `BASE_URL/images/**/*` instead of `/images/**/*`
- Cannot be verified in dev, since dev continues to showcase the same behavior, needs to be pushed and built to check production
- I have implemented this change across some other frontend websites in the past and it has solved