### PR TITLE
Fixing the order of the footnotes in Calculus Chapter 6

### DIFF
--- a/public/content/lessons/2017/eulers-number/index.mdx
+++ b/public/content/lessons/2017/eulers-number/index.mdx
@@ -85,9 +85,9 @@ More abstractly, for some tiny change in time $dt$, we want to understand the di
   image="figures/finding-the-derivative/base-2-rate-of-change.svg" 
 />
 
-Here’s the thing. I would love if there was some clear geometric picture that made what’s about to follow just pop out. Some diagram where you could point to one value and say "see that part, that is the derivative of $2^t$". If you know of one, please, let me know[^3]. And while the goal here, as with the rest of the series, is to maintain a spirit of playful discovery, the type of play that follows will have more to do with finding numerical patterns, rather than visual ones.
+Here’s the thing. I would love if there was some clear geometric picture that made what’s about to follow just pop out. Some diagram where you could point to one value and say "see that part, that is the derivative of $2^t$". If you know of one, please, let me know[^1]. And while the goal here, as with the rest of the series, is to maintain a spirit of playful discovery, the type of play that follows will have more to do with finding numerical patterns, rather than visual ones.
 
-[^3]: [Contact Page](/contact#contact)
+[^1]: [Contact Page](/contact#contact)
 
 ## Finding the Derivative
 
@@ -169,9 +169,9 @@ For any other base to your exponent you can have fun seeing what the various pro
   caption="Notice how the proportionality constant for the derivative changes from less than $1$ for a base of $2$ to greater than $1$ for a base of $3$."
 />
 
-For example, if you plug in $8$ as the base of the exponential function, you can see the relevant proportionality constant is around $2.079$. And maybe, just maybe, you would notice that this number happens to be exactly $3$ times the constant associated with the base of $2$. So these numbers aren’t random, there is some pattern. But what is the pattern? What does $2$ have to do with $0.6931$ and what does $8$ have to do with $2.079$.[^1]
+For example, if you plug in $8$ as the base of the exponential function, you can see the relevant proportionality constant is around $2.079$. And maybe, just maybe, you would notice that this number happens to be exactly $3$ times the constant associated with the base of $2$. So these numbers aren’t random, there is some pattern. But what is the pattern? What does $2$ have to do with $0.6931$ and what does $8$ have to do with $2.079$.[^2]
 
-[^1]: The important observation to make here is that these proportionality constants behave like a logarithm function. In fact, these constants are exactly the output of the natural logarithm function.
+[^2]: The important observation to make here is that these proportionality constants behave like a logarithm function. In fact, these constants are exactly the output of the natural logarithm function.
 
     If you are able to find a function that when given a base has the behavior of $f(1) = 0$, $f(2) = 0.6931$, $f(3) = 1.099$, etc. you would be inventing the natural logarithm function which is one of the paths of discovery for the exponential function and Euler's Number.
 
@@ -184,9 +184,9 @@ A second question, which ultimately explains these mystery constants, is whether
 
 ## Euler's Number
 
-As it turns out, there is a number. It’s the special constant $e$, around $2.71828$, called Euler's number. In fact, it’s not just that $e$ happens to show up here, this is, in a sense, what defines the number $e$ [^2]. This special exponential function with Euler's Number as the base is called *the exponential function*. <!-- TODO: footnote untangling euler's number from the exponential function -->
+As it turns out, there is a number. It’s the special constant $e$, around $2.71828$, called Euler's number. In fact, it’s not just that $e$ happens to show up here, this is, in a sense, what defines the number $e$ [^3]. This special exponential function with Euler's Number as the base is called *the exponential function*. <!-- TODO: footnote untangling euler's number from the exponential function -->
 
-[^2]: If you ask, why does $e$ of all numbers have this property? It's a little like asking why does $\pi$ of all numbers happen to be the ratio of the circumference of a circle to its diameter. This is, at its heart, what defines this value.
+[^3]: If you ask, why does $e$ of all numbers have this property? It's a little like asking why does $\pi$ of all numbers happen to be the ratio of the circumference of a circle to its diameter. This is, at its heart, what defines this value.
 
 <Figure
   image="figures/exponential-function/eulers-number-value-derivative.svg"


### PR DESCRIPTION
<!-- Use this checklist if you're making any other changes to the website -->

Website change review checklist:

- [ ] I have requested a review from the appropriate persons
- [ ] I have checked that my changes work in the preview
- [ ] I have checked that the rest of the site is still functioning in the preview
- [ ] I have checked that my content/code is consistent with existing content/code
- [ ] I have used components in the places and ways they are intended (see the readme)
- [ ] I have formatted all of my code with Prettier

<!-- List what this pull request adds/changes/removes/fixes. Paste into message box when you squash merge. -->

This pull request:

-fixes the order of the footnotes in Calculus Chapter 6

Sorry if I've not done this correctly. I'm not very experienced with Github.
