### PR TITLE
Changing reference to "footnote video" to "previous lesson"

### DIFF
--- a/public/content/lessons/2017/implicit-differentiation/index.mdx
+++ b/public/content/lessons/2017/implicit-differentiation/index.mdx
@@ -207,7 +207,7 @@ From there, depending on what problem you're solving, you could manipulate furth
 
 ## Finding derivative of ln(x)
 
-As one more example, let me show how you can use this technique to help find new derivative formulas. I've mentioned in a footnote video that the derivative of $e^x$ is itself, but what about the derivative of its inverse function the natural log of $x$?
+As one more example, let me show how you can use this technique to help find new derivative formulas. I've mentioned in a previous lesson that the derivative of $e^x$ is itself, but what about the derivative of its inverse function the natural log of $x$?
 
 <Figure
   image="figures/natural-logarithm-plot.svg" 


### PR DESCRIPTION
<!-- Use this checklist if you're making any other changes to the website -->

Website change review checklist:

- [ ] I have requested a review from the appropriate persons
- [ ] I have checked that my changes work in the preview
- [ ] I have checked that the rest of the site is still functioning in the preview
- [ ] I have checked that my content/code is consistent with existing content/code
- [ ] I have used components in the places and ways they are intended (see the readme)
- [ ] I have formatted all of my code with Prettier

<!-- List what this pull request adds/changes/removes/fixes. Paste into message box when you squash merge. -->

This pull request:

-changed a reference to something being mentioned in a "footnote video" to it being mentioned in a "previous lesson" as the text adaption of the video in question is treated no differently from any other text adaption, hence making this reference a little odd.
