### PR TITLE
Add licenses

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+Copyright (c) 2024 3Blue1Brown LLC
+
+This repository has a dual license, in which the written blog and image content within the "public" subdirectory of this repository is not open source, with all rights reserved to 3Blue1Brown LLC. The remaining sourcecode for the respository outside the "public" subdirectory is open source, under the following MIT License.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files excluding the blog posts and media within the "public" subdirectory (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/public/LICENSE.md
+++ b/public/LICENSE.md
@@ -1,0 +1,9 @@
+# Copyright Notice for Blog Content
+
+Copyright (c) 2024 3Blue1Brown LLC
+
+All rights reserved for the content in this directory and subdirectories. This includes all written blog posts, images, and other media.
+
+No permission is granted to use, copy, publish, distribute, sublicense, and/or sell copies of the content in this directory and subdirectories.
+
+By submitting a pull request, contributors agree that their changes can be incorporated under this existing license and that they relinquish any claim to the modifications they submit.


### PR DESCRIPTION
Add a dual license for which the underlying tooling (including react components, etc) is open source, but the blog post content is not.