### PR TITLE
Fix broken lesson contributor links

### DIFF
--- a/components/AboutPageGallery/index.js
+++ b/components/AboutPageGallery/index.js
@@ -21,7 +21,7 @@ const TeamMemberLinks = ({ links }) => {
 
 const TeamMember = ({ name, role, imageSrc, links }) => {
     return (
-        <div className={styles.teamMember}>
+        <div className={styles.teamMember} id={name.toLowerCase().split(' ').join('-')}>
             <div className={styles.headshot}>
                 <img src={imageSrc} alt={name} />
             </div>
@@ -47,6 +47,5 @@ const AboutPageGallery = () => {
         </div>
     );
 };
-
 
 export { AboutPageGallery, TeamMember };

--- a/components/AboutPageGallery/index.module.scss
+++ b/components/AboutPageGallery/index.module.scss
@@ -8,6 +8,7 @@
 .teamMember {
     text-align: center;
     width: 200px;
+    padding-top: 1.5rem;   
 
     .headshot {
         width: 100%;

--- a/data/credits.yaml
+++ b/data/credits.yaml
@@ -3,10 +3,10 @@
 - name: James Schloss
   link: /about#james-schloss
 - name: Josh Pullen
-  link: /about#josh-pullen-2021-intern
+  link: /about#josh-pullen
 - name: River Way
-  link: /about#river-way-2021-intern
+  link: /about#river-way
 - name: Kurt Bruns
-  link: /about#kurt-bruns-artist
+  link: /about#kurt-bruns
 - name: Vivek Verma
-  link: /about#vivek-verma-2021-intern
+  link: /about#vivek-verma

--- a/data/teamMemberData.js
+++ b/data/teamMemberData.js
@@ -27,9 +27,14 @@ const teamMembers = [
     imageSrc: "images/about/kurt-bruns.png",
     links: [
       {
-        icon: "fab fa-github",
-        url: "https://kurtbruns.github.io/",
-        label: "Kurt's Github",
+        icon: "fab fa-youtube",
+        url: "https://www.youtube.com/@wumbo_dot_net",
+        label: "Kurt's Youtube",
+      },
+      {
+        icon: "fa-solid fa-globe",
+        url: "https://kurtbruns.com/",
+        label: "Kurt's Website",
       },
     ],
   },


### PR DESCRIPTION
This pull request:

- Updates `credits.yaml` to contain valid links to contributors in the "about" page when navigating from a lesson
- Adds padding to the top of team member cards so there is some breathing room when navigating to a team contributor's info. For example, when navigating to: `https://www.3blue1brown.com/about#james-schloss`.
- Updates Kurt's social links

Notes:

The `credits.yaml` file could probably be removed entirely, but it would require modifying some logic in `components/LessonDetails/index.js`.
