### PR TITLE
Remove EOA preview lessons

### DIFF
--- a/data/topics.yaml
+++ b/data/topics.yaml
@@ -22,7 +22,6 @@
   slug: linear-algebra
   description: An introduction to visualizing what matrices are really doing
   lessons:
-    - eola-preview
     - vectors
     - span
     - linear-transformations


### PR DESCRIPTION
This pull request:

- Removes the Essence of Linear Algebra Preview lesson from the series overview

