### PR TITLE
Fix Essence of Calculus Navigation

### DIFF
--- a/data/topics.yaml
+++ b/data/topics.yaml
@@ -4,7 +4,6 @@
   lessons:
     - essence-of-calculus
     - derivatives
-    - derivative-formulas-geometrically
     - derivatives-power-rule
     - derivatives-trig-functions
     - chain-rule-and-product-rule


### PR DESCRIPTION
This pull request:

- Removes a phantom lesson "derivative-formulas-geometrically" from `topics.yaml`
- Currently, when on the [derivatives](https://www.3blue1brown.com/lessons/derivatives) lesson, there is no link to the next lesson at the end of the chapter. Also, if you press the next arrow in the video carousel you get a page not found error.
