### PR TITLE
fix eigenvector puzzle hints in linear algebra series, fix latex typo

### DIFF
--- a/public/content/lessons/2016/eigenvalues/index.mdx
+++ b/public/content/lessons/2016/eigenvalues/index.mdx
@@ -759,7 +759,7 @@ We can find the eigenvalues of this matrix by subtracting a variable $\lambda$ o
 
 $$
 \begin{align*}
-	\det([A - \lambda I) = 
+	\det(A - \lambda I) = 
 	\det\left(\left[
 		\begin{array}{cc}
 			0 - \lambda & 1 \\

--- a/public/content/lessons/2016/eigenvalues/index.mdx
+++ b/public/content/lessons/2016/eigenvalues/index.mdx
@@ -543,11 +543,11 @@ Given that two eigenvectors of this matrix are
 
 $$
 \overrightarrow{\mathbf{v}}_1=\left[\begin{array}{c}
-2 \\
-1+\sqrt{5}
+\frac{1}{2}(-1 + \sqrt{5}) \\
+1
 \end{array}\right] \quad \overrightarrow{\mathbf{v}}_2=\left[\begin{array}{c}
-2 \\
-1-\sqrt{5}
+\frac{1}{2}(-1 - \sqrt{5}) \\
+1
 \end{array}\right],
 $$
 


### PR DESCRIPTION
The eigenvectors v1 and v2 given as hints in the puzzle are wrong. I replaced them with the correct ones copied from the puzzle solution.