### PR TITLE
Communitive -> commutative

### DIFF
--- a/public/content/lessons/2016/matrix-multiplication/index.mdx
+++ b/public/content/lessons/2016/matrix-multiplication/index.mdx
@@ -341,7 +341,7 @@ The overall effect is very different, so it would appear that order totally does
 
 <Accordion title="Numerical Proof">
 
-We could show that matrix multiplication isn't communitive through numerical computation:
+We could show that matrix multiplication isn't commutative through numerical computation:
 $$
 \begin{align*}
 \color{purple}


### PR DESCRIPTION
This pull request:

- Replaces the word "communitive" with the word "commutative" in the lesson on [https://www.3blue1brown.com/lessons/matrix-multiplication](matrix multiplication)
