### PR TITLE
typo: "eachother" -> "each other" in line 376

### DIFF
--- a/public/content/lessons/2016/3d-transformations/index.mdx
+++ b/public/content/lessons/2016/3d-transformations/index.mdx
@@ -373,7 +373,7 @@ Here's another puzzle for you: It's also meaningful to talk about a linear trans
 
 <FreeResponse>
 
-A simple example from 3d to 2d would be the shadow cast by a 3d object onto a 2d plane. Although, in order for the transformation to be linear, the light rays should be considered parallel to eachother to simplify the problem. If you consider the light source to be something really far away, like the sun, then this is a reasonable choice to make.
+A simple example from 3d to 2d would be the shadow cast by a 3d object onto a 2d plane. Although, in order for the transformation to be linear, the light rays should be considered parallel to each other to simplify the problem. If you consider the light source to be something really far away, like the sun, then this is a reasonable choice to make.
 
 You can represent these transformations with matrices. The number of columns corresponds to the dimension of the input and the number of rows corresponds to the dimension of the output. For example, a matrix that maps coordinates in 3d to 2d would have three columns and two rows.
 


### PR DESCRIPTION
This pull request:

- corrects a typo (`eachother` to `each other`) in line 376 of the file.
