### PR TITLE
Fix search console warnings

### DIFF
--- a/app/components/Meta.tsx
+++ b/app/components/Meta.tsx
@@ -1,4 +1,5 @@
 import type { Thing, WithContext } from "schema-dts";
+import { useLocation } from "react-router";
 import { JsonLd } from "react-schemaorg";
 import { truncate } from "lodash-es";
 import site from "~/data/site.json";
@@ -18,6 +19,9 @@ export default function Meta<Type extends Thing>({
   description,
   jsonLd,
 }: Props<Type>) {
+  const { pathname } = useLocation();
+  const canonicalUrl = new URL(pathname, site.url).href;
+
   const combinedTitle = [title, site.title]
     .flat()
     .filter(Boolean)
@@ -30,12 +34,13 @@ export default function Meta<Type extends Thing>({
     <>
       <title>{combinedTitle}</title>
 
+      <link rel="canonical" href={canonicalUrl} />
       <meta name="title" content={combinedTitle} />
       <meta name="description" content={combinedDescription} />
       <link rel="icon" type="image/svg" href="/icon.svg" />
 
       <meta property="og:type" content="website" />
-      <meta property="og:url" content={site.url} />
+      <meta property="og:url" content={canonicalUrl} />
       <meta property="og:title" content={combinedTitle} />
       <meta property="og:description" content={combinedDescription} />
       <meta property="og:image" content="/share.jpg" />

--- a/app/data/site.json
+++ b/app/data/site.json
@@ -1,7 +1,7 @@
 {
   "title": "3Blue1Brown",
   "description": "Mathematics with a distinct visual perspective. Linear algebra, calculus, neural networks, topology, and more.",
-  "url": "https://3blue1brown.com",
+  "url": "https://www.3blue1brown.com",
 
   "github_org": "3b1b",
   "github_repo": "3blue1brown.com",

--- a/app/pages/lessons/Lesson.tsx
+++ b/app/pages/lessons/Lesson.tsx
@@ -1,8 +1,9 @@
-import type { Article } from "schema-dts";
+import type { Article, VideoObject } from "schema-dts";
 import type { Lesson, RawLesson } from "~/pages/lessons/lessons";
 import type { Route } from "./+types/Lesson";
 import { use } from "react";
 import { href } from "react-router";
+import { JsonLd } from "react-schemaorg";
 import { Fragment } from "react/jsx-runtime";
 import {
   ArrowLeftIcon,
@@ -101,6 +102,20 @@ export default function Lesson({ params: { id } }: Route.ComponentProps) {
           articleSection: chapter !== -1 ? `Chapter ${chapter}` : undefined,
         }}
       />
+
+      {video && (
+        <JsonLd<VideoObject>
+          item={{
+            "@context": "https://schema.org",
+            "@type": "VideoObject",
+            name: title,
+            description,
+            thumbnailUrl: image,
+            uploadDate: date.toISOString(),
+            embedUrl: `https://www.youtube.com/embed/${video}`,
+          }}
+        />
+      )}
 
       <Header />
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Disallow:
-Sitemap: https://3blue1brown.com/sitemap.xml
+Sitemap: https://www.3blue1brown.com/sitemap.xml


### PR DESCRIPTION
I got two warnings from Google Search Console, one about some pages not indexing properly, one about video structure data issues.

The suggested fix for the former was to better acknowledge the "www" variant as the canonical URL. The latter probably doesn't matter immensely, but I suppose it makes it easier for video metadata to be read by crawlers.