### PR TITLE
Add possible fixes for caching error

### DIFF
--- a/app/components/DarkMode.tsx
+++ b/app/components/DarkMode.tsx
@@ -30,6 +30,7 @@ export default function DarkMode({ className = "" }) {
 
   // for debugging
   useEventListener("keydown", ({ key, ctrlKey, altKey, shiftKey, metaKey }) => {
+    if (!import.meta.env.DEV) return;
     if (key.toLowerCase() === "d" && (ctrlKey || altKey || shiftKey || metaKey))
       setDarkMode((darkMode) => !darkMode);
   });

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -110,3 +110,11 @@ export function ErrorBoundary({ error }: { error: Error }) {
     </html>
   );
 }
+
+// https://vite.dev/guide/build#load-error-handling
+if (typeof window !== "undefined")
+  window.addEventListener("vite:preloadError", (event) => {
+    console.debug(event);
+    // force refresh to get new assets
+    window.location.reload();
+  });

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,11 +2,21 @@
 command = "bun run build"
 publish = "build/client"
 
-  [build.environment]
-  NODE_VERSION = "22"
+[build.environment]
+NODE_VERSION = "24"
 
 [dev]
 command = "bun run dev"
+
+[[headers]]
+for = "/*"
+[headers.values]
+Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+for = "/assets/*"
+[headers.values]
+Cache-Control = "public, max-age=31536000, immutable"
 
 [[redirects]]
 from = "https://3b1b.co/*"


### PR DESCRIPTION
Closes #595 

[Here is a long Claude conversation about this, discussing possible causes and solution](https://github.com/user-attachments/files/27184934/Claude-Stale.HTML.caching.with.outdated.JavaScript.hashes.pdf) (this stuff is not my strong suit).

- Remove dark mode keyboard shortcut (only intended for dev/testing, forgot to remove before)
- Handle "vite preload" error
- Add explicit cache headers to Netlify config

The vite preload error should catch the very specific situation (and possibly the cause of some of #595): the user has an HTML page on the site open (for a few days, let's say), we make an update to the site (which changes the filename hashes of some assets), the user then does something that makes the old HTML try to dynamically fetch some more content with JS (e.g. `await import("./some-new-page-9d82n3f.js")`), but that content no longer exists (because we changed the site enough that the filename hash changed) it so we get an error. This added error handling will just force a page refresh in that case.

The headers added to the config should mostly be a no-op. Supposedly Netlify already sets `max-age=0, must-revalidate` by default, but I guess it doesn't hurt to be explicit. Then, because everything in `/assets` is hashed and thus self-cache-busting by virtue of Vite, we can tell Netlify they can be cached longer than the default.

---

I will say, if these things _don't_ fix #595, I don't know what else could, other than running our own CDN or finding a CDN service that allows complete control over all network stuff. Or without the user providing a ton more debugging info like installed extensions, data dumps, more screenshots, etc.

Note that the user in #595 would have to refresh at least once after we merge this to see these new changes take effect.