### PR TITLE
Improve flaky e2e tests

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,4 +1,4 @@
-name: Deep test
+name: Checks (expect errors)
 
 on:
   schedule:
@@ -7,38 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-e2e:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install packages
-        run: bun install
-
-      - name: SSH debug
-        if: runner.debug == '1'
-        uses: mxschmitt/action-tmate@v3
-
-      - name: Install Playwright
-        run: bun run install-playwright
-
-      - name: Run test
-        run: ROUTE= bun run test:e2e
-
-      - name: Upload test reports
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: reports
-          path: |
-            ./frontend/playwright-report
-            ./frontend/lighthouse-report
-          retention-days: 30
-
   check-spelling:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -108,6 +108,6 @@ jobs:
         with:
           name: reports
           path: |
-            ./frontend/playwright-report
-            ./frontend/lighthouse-report
+            ./playwright-report
+            ./lighthouse-report
           retention-days: 30

--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -29,7 +29,7 @@ export default function Card({
     <Link
       arrow={false}
       className={clsx(
-        "group relative isolate grid rounded-md text-black no-underline outline-none hocus:scale-102",
+        "group relative isolate grid rounded-md text-black no-underline outline-none hocus:scale-101",
         direction === "row"
           ? "grid-cols-3 gap-8 max-md:grid-cols-2 max-sm:grid-cols-1"
           : "grid-cols-1 place-items-center justify-start gap-4 text-center text-balance",
@@ -44,7 +44,7 @@ export default function Card({
 
       <div
         className={clsx(
-          "flex flex-2 flex-col gap-4",
+          "flex flex-col gap-2",
           direction === "row"
             ? "col-span-2 items-start justify-center max-md:col-span-1"
             : "items-center",

--- a/app/components/MathJax.tsx
+++ b/app/components/MathJax.tsx
@@ -26,10 +26,7 @@ export default function MathJax() {
             return render();
     },
     () => document.body,
-    {
-      subtree: true,
-      childList: true,
-    },
+    { subtree: true, childList: true },
   );
 
   return null;
@@ -40,79 +37,98 @@ declare global {
   interface Window {
     // eslint-disable-next-line
     MathJax: any;
+    MathJaxState?: boolean;
   }
 }
 
 // initialize mathjax
 const init = async () => {
-  // ensure only one load
-  if (window.MathJax) return;
+  console.debug("MathJax init start");
+  try {
+    // ensure only one load
+    if (window.MathJax) {
+      console.debug("MathJax init skip");
+      return;
+    }
 
-  // configure
-  window.MathJax = {
-    svg: {
-      fontCache: "local",
-    },
-    loader: {
-      load: ["[tex]/color"],
-    },
-    tex: {
-      packages: {
-        "[+]": ["color"],
-        // force undefined macros to throw and render merror dom element
-        "[-]": ["noundefined"],
+    // configure
+    window.MathJax = {
+      svg: {
+        fontCache: "local",
       },
-      macros: {
-        degree: "{^\\circ}",
+      loader: {
+        load: ["[tex]/color"],
       },
-      // force parsing errors to throw and render merror dom element
-      formatError: (jax: unknown, error: Error) => {
-        error.name = "MathJaxError";
-        throw error;
+      tex: {
+        packages: {
+          "[+]": ["color"],
+          // force undefined macros to throw and render merror dom element
+          "[-]": ["noundefined"],
+        },
+        macros: {
+          degree: "{^\\circ}",
+        },
+        // force parsing errors to throw and render <merror> dom element
+        formatError: (jax: unknown, error: Error) => {
+          error.name = "MathJaxError";
+          throw error;
+        },
       },
-    },
-    startup: {
-      typeset: false,
-    },
-  };
+      startup: {
+        typeset: false,
+      },
+    };
 
-  // load from node_modules
-  const script = document.createElement("script");
-  script.src = cdn;
-  script.type = "text/javascript";
-  script.async = true;
-  document.head.appendChild(script);
-  await new Promise((resolve, reject) => {
-    script.onload = resolve;
-    script.onerror = reject;
-  });
-  // wait for mathjax to start up
-  await window.MathJax.startup?.promise;
+    // load from node_modules
+    const script = document.createElement("script");
+    script.src = cdn;
+    script.type = "text/javascript";
+    script.async = true;
+    document.head.appendChild(script);
+    await new Promise((resolve, reject) => {
+      script.onload = resolve;
+      script.onerror = reject;
+    });
+    console.debug("MathJax startup start");
+    // wait for mathjax to start up
+    await window.MathJax.startup?.promise;
+  } catch (error) {
+    console.error("MathJax init error", error);
+  }
+  console.debug("MathJax init finish");
 };
 
 const render = async () => {
-  // get output from remark-math, which processes $ math blocks into <code> elements
-  const elements = document.querySelectorAll("code.language-math");
-  for (const element of elements) {
-    // math tex content
-    const math = element.textContent ?? "";
-    // parent container
-    const parent = element.parentElement;
-    if (!parent) continue;
-    // block vs inline math
-    const display = parent.matches("pre");
-    if (display) parent.classList.add("contents");
-    // convert to svg content
-    let content: Element | undefined = undefined;
-    try {
-      // try synchronous for responsiveness
-      content = window.MathJax.tex2svg?.(math, { display });
-    } catch (error) {
-      // fallback to async if things still loading
-      content = await window.MathJax.tex2svgPromise?.(math, { display });
+  console.debug("MathJax render start");
+  try {
+    // get output from remark-math, which processes $ math blocks into <code> elements
+    const elements = document.querySelectorAll("code.language-math");
+    console.debug(`MathJax render ${elements.length} elements`);
+    for (const element of elements) {
+      // math tex content
+      const math = element.textContent ?? "";
+      // parent container
+      const parent = element.parentElement;
+      if (!parent) continue;
+      // block vs inline math
+      const display = parent.matches("pre");
+      if (display) parent.classList.add("contents");
+      // convert to svg content
+      let content: Element | undefined = undefined;
+      try {
+        // try synchronous for responsiveness
+        content = window.MathJax.tex2svg?.(math, { display });
+      } catch (error) {
+        // fallback to async if things still loading
+        content = await window.MathJax.tex2svgPromise?.(math, { display });
+      }
+      if (!content) continue;
+      // insert content
+      element.replaceWith(content);
     }
-    if (!content) continue;
-    // insert content
-    element.replaceWith(content);
+    console.debug("MathJax render finish");
+  } catch (error) {
+    console.error("MathJax render error", error);
   }
+  window.MathJaxState = true;
 };

--- a/app/pages/blog/Book.tsx
+++ b/app/pages/blog/Book.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import Link from "~/components/Link";
+import Card from "~/components/Card";
 
 type Props = {
   title: string;
@@ -11,14 +11,10 @@ type Props = {
 
 export default function Book({ title, author, link, image, children }: Props) {
   return (
-    <div className="flex flex-col gap-8 no-underline">
-      <Link
-        to={link}
-        arrow={false}
-        className="aspect-video w-full overflow-hidden bg-light-gray hocus-ring"
-      >
-        <img src={image} alt={title} className="size-full object-contain" />
-      </Link>
+    <div className="flex flex-col gap-8">
+      <Card to={link} className="bg-light-gray">
+        <img src={image} alt={title} className="h-50" />
+      </Card>
       <strong className="font-medium">{title}</strong>
       <em className="-mt-4">{author}</em>
       {children}

--- a/app/pages/blog/recommendations/index.mdx
+++ b/app/pages/blog/recommendations/index.mdx
@@ -54,14 +54,14 @@ For building up your fundamentals, say starting with algebra, take a look at [Kh
 
 ## Other YouTube channels
 
-<div className="grid grid-cols-[auto_1fr] place-items-center gap-12 max-md:grid-cols-1">
+<div className="grid grid-cols-[auto_4fr] place-items-center gap-12 max-md:grid-cols-1">
 
 <Portrait
   image={mathologer}
   name="Mathologer"
   description="Burkard Polster"
   link="https://www.youtube.com/channel/UC1_uAIS3r8Vu6JjXWvastJg"
-  className="w-100"
+  className="w-40"
 />
 
 Half of the appeal here comes from the delightful bits of math this channel covers, often with novel ways of presenting otherwise extremely complicated topics to make them easier. For example, he has a video showing [why $\pi$ is transcendental](https://www.youtube.com/watch?v=WyoH_vgiqXM), which is a famously difficult topic, but which he skillfully boils down into an approachable step-by-step presentation. The other half of the appeal is watching Burkard delightedly laugh at his own jokes every 2 minutes or so.
@@ -71,7 +71,7 @@ Half of the appeal here comes from the delightful bits of math this channel cove
   name="Numberphile"
   description="Brady Haran"
   link="https://www.youtube.com/user/numberphile"
-  className="w-100"
+  className="w-40"
 />
 
 I'm guessing if you're here, you already know about Numberphile. If somehow you don't, it's a great channel full of interviews with mathematicians. As a result, you see a wide array of the types of topics which different mathematicians find exciting to showcase or teach, and a little more of the human element behind this subject. There is also an [associated podcast](https://www.numberphile.com/podcast), less about the math, and more about those human stories.
@@ -81,7 +81,7 @@ I'm guessing if you're here, you already know about Numberphile. If somehow you 
   name="Standup Maths"
   description="Matt Parker"
   link="https://www.youtube.com/user/standupmaths"
-  className="w-100"
+  className="w-40"
 />
 
 This channel is more whimsical and comedic, but that's not to say there isn't a lot of serious math it covers.
@@ -91,7 +91,7 @@ This channel is more whimsical and comedic, but that's not to say there isn't a 
   name="Looking Glass Universe"
   description="Mithuna Yoganathan"
   link="https://www.youtube.com/user/LookingGlassUniverse"
-  className="w-100"
+  className="w-40"
 />
 
 She covers ideas from physics and math explained simply and unusually honestly. Start with the [one on spin](https://www.youtube.com/watch?v=cd2Ua9dKEl8), it's great. She also places an emphasis on doing practice, often assigning "homework" at the end of each video. Also, can we just step back to appreciate that the four channels above are all run by people either from or based in Australia? What's going on over there? And that's not even counting [Tibees](https://www.youtube.com/user/tibees), [Eddy Woo](https://www.youtube.com/user/misterwootube), [James Tanton](https://www.youtube.com/channel/UCib_J32VI8rQI_LCFXn1XAA) and countless others.
@@ -101,7 +101,7 @@ She covers ideas from physics and math explained simply and unusually honestly. 
   name="Welch Labs"
   description="Stephen Welch"
   link="https://www.youtube.com/user/Taylorns34"
-  className="w-100"
+  className="w-40"
 />
 
 Perhaps best known for his [series on imaginary numbers](https://www.youtube.com/watch?v=T647CGsuOVU&list=PLiaHhY2iBX9g6KIvZ_703G3KJXapKkNaF), this channel is full of high production quality and well-written videos. There are also several series on machine learning, the topics underlying self-driving cars, so this is certainly one of the more applied math channels out there.
@@ -111,7 +111,7 @@ Perhaps best known for his [series on imaginary numbers](https://www.youtube.com
   name="Black Pen Red Pen"
   description="Steve Chow"
   link="https://www.youtube.com/channel/UC_SvYP0k05UKiJ_2ndB02IA"
-  className="w-100"
+  className="w-40"
 />
 
 If you like seeing how to work out integrals in all sorts of crazy ways, boy is this the channel for you. Steven is a math teacher, and the videos have a feeling of being in office hours, honestly working through problems with a very skillful and enthusiastic teacher. Many of the problems covered are the kind you might come across in school, and many or just for fun.
@@ -121,7 +121,7 @@ If you like seeing how to work out integrals in all sorts of crazy ways, boy is 
   name="Patrick JMT"
   description="Patrick"
   link="https://www.youtube.com/user/patrickJMT"
-  className="w-100"
+  className="w-40"
 />
 
 If you want good, honest worked examples of practice problems, especially for calculus, it's hard to find a deeper well of examples than what this channel provides.

--- a/app/pages/extras/Blog.tsx
+++ b/app/pages/extras/Blog.tsx
@@ -10,7 +10,7 @@ import { formatDate } from "~/util/string";
 export default function Blog() {
   return (
     <section className="bg-secondary/10">
-      <H2>Written Posts</H2>
+      <H2>Posts</H2>
 
       <div className="grid grid-cols-2 gap-8 max-sm:grid-cols-1">
         {orderBy(
@@ -27,10 +27,13 @@ export default function Blog() {
             <Card
               key={id}
               to={href("/blog/:id", { id })}
-              className="items-start gap-2 bg-secondary/5 p-4 text-left"
-              title={title}
-              description={`${formatDate(date)} — ${description}`}
+              className="justify-items-start bg-secondary/5 p-4"
             >
+              <div className="w-full text-left font-sans">{title}</div>
+              <div className="w-full text-left text-gray">
+                {formatDate(date)}
+              </div>
+              <div className="w-full text-left">{description}</div>
               <FeatherIcon className="absolute top-1/2 right-0 size-20 -translate-y-1/2 text-xl text-secondary opacity-10" />
             </Card>
           );

--- a/app/pages/home/Hero.tsx
+++ b/app/pages/home/Hero.tsx
@@ -78,7 +78,7 @@ export default function Hero() {
           </Button>
           <Button to={site.socials.newsletter} color="light">
             <NewspaperIcon />
-            Mailing list
+            Mailing List
           </Button>
         </div>
       </div>

--- a/app/pages/home/Lessons.tsx
+++ b/app/pages/home/Lessons.tsx
@@ -143,7 +143,7 @@ export function Search({ dialog = false, close = () => {} }) {
       {!topicId?.trim() && !search.trim() ? (
         <div
           id="results"
-          className="grid grid-cols-3 gap-8 max-md:grid-cols-2 max-sm:grid-cols-1"
+          className="grid grid-cols-3 gap-8 max-md:grid-cols-2 max-sm:grid-cols-2"
         >
           {Object.entries(topics).map(([id, { title, image }]) => (
             <Card

--- a/app/pages/home/Patreon.tsx
+++ b/app/pages/home/Patreon.tsx
@@ -39,7 +39,7 @@ export default function Patreon() {
             to="https://members.3blue1brown.com/posts/solution-to-sum-156593740"
             color="light"
           >
-            New video (early access)
+            New Video (Early Access)
             <ArrowRightIcon />
           </Button>
         </div>

--- a/app/pages/talent/Intro.tsx
+++ b/app/pages/talent/Intro.tsx
@@ -15,7 +15,7 @@ export default function Intro() {
       <PiCreature
         emotion="well"
         size="md"
-        className="absolute bottom-10 left-10 max-xl:hidden"
+        className="absolute bottom-10 left-32 max-xl:hidden"
       />
     </section>
   );

--- a/app/pages/talent/janestreet/index.mdx
+++ b/app/pages/talent/janestreet/index.mdx
@@ -2,10 +2,9 @@
 name: Jane Street
 tagline: Quantitative trading and technology
 quote: Everybody here is a math nerd. If you go up to someone and start explaining a math puzzle, they'll stop you before you can tell them how to solve it because they want to try it on their own.
-test: <>five</>
 ---
 
-import { ArrowUpRightIcon, GraduationCapIcon } from "@phosphor-icons/react";
+import { ArrowUpRightIcon } from "@phosphor-icons/react";
 import Button from "~/components/Button";
 import Image from "~/components/Image";
 import Quote from "~/components/Quote";

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -15,7 +15,6 @@ import { IconContext } from "@phosphor-icons/react";
 import Analytics from "~/components/Analytics";
 import Celebrate from "~/components/Celebrate";
 import { load as loadDarkMode } from "~/components/DarkMode";
-import Link from "~/components/Link";
 import MathJax from "~/components/MathJax";
 import Navigate from "~/components/Navigate";
 import ViewCorner from "~/components/ViewCorner";
@@ -88,7 +87,8 @@ export default function App() {
 
 // app-wide error fallback
 export function ErrorBoundary({ error }: { error: Error }) {
-  // keep this simple to avoid errors in error boundary itself
+  console.error(error);
+  // keep this as simple as possible to avoid errors in error boundary itself
   return (
     <html lang="en">
       <head>
@@ -101,7 +101,9 @@ export function ErrorBoundary({ error }: { error: Error }) {
           <h1>Error</h1>
           <p>
             We're sorry, something went wrong. Please{" "}
-            <Link to={site.github_issues}>let us know about it.</Link>
+            <a href={site.github_issues} target="_blank">
+              let us know about it.
+            </a>
           </p>
           <p className="text-error">{error.stack}</p>
           <p>Open your browser's developer console for more details.</p>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,16 +6,29 @@ const url = `http://localhost:${port}`;
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
-  workers: "75%",
+  // workers: 1,
   reporter: [["html", { open: process.env.CI ? "never" : "on-failure" }]],
 
   use: {
     baseURL: url,
+    // headless: !!process.env.CI,
     trace: "on",
   },
 
   projects: [
-    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: {
+          args: [
+            "--disable-background-timer-throttling",
+            "--disable-renderer-backgrounding",
+            "--disable-backgrounding-occluded-windows",
+          ],
+        },
+      },
+    },
     // { name: "firefox", use: { ...devices["Desktop Firefox"] } },
     // { name: "webkit", use: { ...devices["Desktop Safari"] } },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,14 +5,13 @@ const url = `http://localhost:${port}`;
 
 export default defineConfig({
   testDir: "./tests",
-  retries: 2,
   fullyParallel: true,
   workers: "75%",
   reporter: [["html", { open: process.env.CI ? "never" : "on-failure" }]],
 
   use: {
     baseURL: url,
-    trace: "on-first-retry",
+    trace: "on",
   },
 
   projects: [
@@ -22,9 +21,9 @@ export default defineConfig({
   ],
 
   webServer: {
-    // command: "bun run build && bun run preview",
-    command: "bun run dev",
+    command: "bun run build && bun run preview",
+    // command: "bun run preview",
+    // command: "bun run dev",
     url,
-    reuseExistingServer: true,
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,13 +6,13 @@ const url = `http://localhost:${port}`;
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
-  workers: 1,
+  workers: process.env.CI ? 1 : "75%",
   reporter: [["html", { open: process.env.CI ? "never" : "on-failure" }]],
 
   use: {
     baseURL: url,
     // headless: !!process.env.CI,
-    trace: "on",
+    trace: "retain-on-failure",
   },
 
   projects: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ const url = `http://localhost:${port}`;
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
-  // workers: 1,
+  workers: "75%",
   reporter: [["html", { open: process.env.CI ? "never" : "on-failure" }]],
 
   use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,6 @@ const url = `http://localhost:${port}`;
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
-  workers: process.env.CI ? 1 : "75%",
   reporter: [["html", { open: process.env.CI ? "never" : "on-failure" }]],
 
   use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ const url = `http://localhost:${port}`;
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
-  workers: "75%",
+  workers: "50%",
   reporter: [["html", { open: process.env.CI ? "never" : "on-failure" }]],
 
   use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ const url = `http://localhost:${port}`;
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
-  workers: "50%",
+  workers: 1,
   reporter: [["html", { open: process.env.CI ? "never" : "on-failure" }]],
 
   use: {

--- a/tests/axe.spec.ts
+++ b/tests/axe.spec.ts
@@ -22,7 +22,7 @@ const checkPage = (route: string) =>
     await page.waitForLoadState();
 
     // wait for some content to appear
-    await page.waitForSelector("footer");
+    await expect(page.locator("footer")).toBeVisible();
 
     // builder
     const builder = new AxeBuilder({ page });

--- a/tests/axe.spec.ts
+++ b/tests/axe.spec.ts
@@ -12,14 +12,17 @@ const checkPage = (route: string) =>
     // test should be independent of browser, so only run one
     test.skip(browserName !== "chromium", "Only test on chromium");
 
-    // test can be slow on ci on very large page (like testbed)
-    test.setTimeout(60 * 1000);
+    // disable mathjax entirely just for this test
+    // trust that it handles accessibility well
+    // by inspection it does, screen readers announce its content
+    // https://docs.mathjax.org/en/v4.0/options/accessibility.html
+    await page.route(
+      (url) => !!url.href.match(/jsdelivr.*mathjax.*\.js/),
+      (route) => route.abort(),
+    );
 
     // navigate to page
     await page.goto(route);
-
-    // wait for load event
-    await page.waitForLoadState();
 
     // wait for some content to appear
     await expect(page.locator("footer")).toBeVisible();
@@ -31,26 +34,10 @@ const checkPage = (route: string) =>
     builder.exclude("iframe");
     builder.exclude("youtube-video");
 
-    // exclude mathjax, trust that it handles accessibility well
-    // by inspection it does, screen readers announce its content
-    // https://docs.mathjax.org/en/v4.0/options/accessibility.html
-    builder.exclude("mjx-container");
-
-    // wait for mathjax to finish first render
-    await page.waitForFunction(() => window.MathJaxState === true);
-
-    // axe throws error if e.g. radio button only has math content
-    // mjx-container has no typical accessible text attr e.g. aria-label
-    // but by inspection, screen readers can still find and announce its content
-    // so, add fake accessible label to satisfy axe
-    await page.evaluate(() =>
-      document
-        .querySelectorAll("mjx-container")
-        .forEach((element) => element.setAttribute("aria-label", "fake label")),
-    );
-
     // get page violations
-    const { violations } = await builder.analyze();
+    const { violations } = await test.step("analyze", () => builder.analyze(), {
+      timeout: 30 * 1000,
+    });
 
     // split up critical/non-critical
     const { critical = [], warning = [] } = groupBy(violations, ({ id }) => {
@@ -76,4 +63,4 @@ const checkPage = (route: string) =>
   });
 
 // check all pages
-await Promise.all(routes.map(checkPage));
+routes.map(checkPage);

--- a/tests/axe.spec.ts
+++ b/tests/axe.spec.ts
@@ -24,7 +24,7 @@ const checkPage = (route: string) =>
     // navigate to page
     await page.goto(route, { waitUntil: "domcontentloaded" });
 
-    // wait for some content to appear
+    // wait for some content to render
     await expect(page.locator("footer")).toBeVisible();
 
     // builder
@@ -36,6 +36,7 @@ const checkPage = (route: string) =>
 
     // get page violations
     const { violations } = await test.step("analyze", () => builder.analyze(), {
+      // can take a while, especially on large pages e.g. testbed
       timeout: 30 * 1000,
     });
 

--- a/tests/axe.spec.ts
+++ b/tests/axe.spec.ts
@@ -36,6 +36,9 @@ const checkPage = (route: string) =>
     // https://docs.mathjax.org/en/v4.0/options/accessibility.html
     builder.exclude("mjx-container");
 
+    // wait for mathjax to finish first render
+    await page.waitForFunction(() => window.MathJaxState === true);
+
     // axe throws error if e.g. radio button only has math content
     // mjx-container has no typical accessible text attr e.g. aria-label
     // but by inspection, screen readers can still find and announce its content

--- a/tests/axe.spec.ts
+++ b/tests/axe.spec.ts
@@ -24,6 +24,9 @@ const checkPage = (route: string) =>
     // navigate to page
     await page.goto(route, { waitUntil: "domcontentloaded" });
 
+    // wait for some content to appear
+    await expect(page.locator("footer")).toBeVisible();
+
     // builder
     const builder = new AxeBuilder({ page });
 

--- a/tests/axe.spec.ts
+++ b/tests/axe.spec.ts
@@ -22,10 +22,7 @@ const checkPage = (route: string) =>
     );
 
     // navigate to page
-    await page.goto(route);
-
-    // wait for some content to appear
-    await expect(page.locator("footer")).toBeVisible();
+    await page.goto(route, { waitUntil: "domcontentloaded" });
 
     // builder
     const builder = new AxeBuilder({ page });

--- a/tests/load.spec.ts
+++ b/tests/load.spec.ts
@@ -53,4 +53,4 @@ const checkPage = (route: string) =>
   });
 
 // check all pages
-await Promise.all(routes.map(checkPage));
+routes.map(checkPage);

--- a/tests/load.spec.ts
+++ b/tests/load.spec.ts
@@ -28,7 +28,7 @@ const checkPage = (route: string) =>
     });
 
     // navigate to page
-    await page.goto(route);
+    await page.goto(route, { waitUntil: "domcontentloaded" });
 
     // wait for all responses to finish
     await Promise.allSettled(responses);

--- a/tests/math.spec.ts
+++ b/tests/math.spec.ts
@@ -21,10 +21,7 @@ const checkPage = (route: string) =>
     });
 
     // navigate to page
-    await page.goto(route);
-
-    // wait for some content to appear
-    await expect(page.locator("footer")).toBeVisible();
+    await page.goto(route, { waitUntil: "domcontentloaded" });
 
     // wait for mathjax to finish first load
     await expect

--- a/tests/math.spec.ts
+++ b/tests/math.spec.ts
@@ -23,11 +23,16 @@ const checkPage = (route: string) =>
     // navigate to page
     await page.goto(route);
 
-    // wait for content to load
-    await page.waitForLoadState();
+    // wait for some content to appear
+    await expect(page.locator("footer")).toBeVisible();
 
-    // wait a bit for mathjax to render
-    await page.waitForTimeout(5000);
+    // wait for mathjax to finish first load
+    await expect
+      // poll on node-side to avoid browser-side timer/raf throttling w/ waitForFunction
+      .poll(async () => page.evaluate(() => window.MathJaxState === true), {
+        timeout: 30 * 1000,
+      })
+      .toBe(true);
 
     test.info().annotations.push({
       type: "MathJax errors",
@@ -39,4 +44,4 @@ const checkPage = (route: string) =>
   });
 
 // check all pages
-await Promise.all(routes.map(checkPage));
+routes.map(checkPage);

--- a/tests/routes.ts
+++ b/tests/routes.ts
@@ -15,7 +15,9 @@ const filter =
             [
               // large, popular, complex, math-only controls
               "/essence-of-calculus",
+              "/zeta",
               // large, interactive
+              "/bitcoin",
               // interactive
               "/newtons-fractal",
               // no text, viz bg

--- a/tests/routes.ts
+++ b/tests/routes.ts
@@ -1,39 +1,42 @@
 import allRoutes from "./routes.json" with { type: "json" };
 
 // by default, ignore less critical and numerous routes (like /lessons and /blog) to speed up tests
-const { ROUTE = "" } = process.env;
+const { ROUTE } = process.env;
 
 // function to filter routes by
-const filter = ROUTE
-  ? // filter by provided regex
-    (path: string) => path.match(new RegExp(ROUTE))
-  : // default filter
-    (path: string) => {
-      if (path.endsWith(".xml")) return false;
+const filter =
+  ROUTE === undefined
+    ? // default filter
+      (path: string) => {
+        // ignore less critical / more numerous routes to speed up tests
+        if (["/lessons", "/blog"].some((p) => path.startsWith(p))) {
+          // but still include representative sample of a few
+          if (
+            [
+              // large, popular, complex, math-only controls
+              "/essence-of-calculus",
+              // large, interactive
+              // interactive
+              "/newtons-fractal",
+              // no text, viz bg
+              "/hilbert-curve",
+              // no text
+              "/laplace-transform",
+            ].some((p) => path.endsWith(p))
+          )
+            return true;
+          return false;
+        }
 
-      // ignore less critical / more numerous routes to speed up tests
-      if (["/lessons", "/blog"].some((p) => path.startsWith(p))) {
-        // but still include representative sample of a few
-        if (
-          [
-            // large, popular, complex, math-only controls
-            "/essence-of-calculus",
-            // large, interactive
-            // interactive
-            "/newtons-fractal",
-            // no text, viz bg
-            "/hilbert-curve",
-            // no text
-            "/laplace-transform/",
-          ].some((p) => path.endsWith(p))
-        )
-          return true;
-        return false;
+        return true;
       }
+    : // filter by provided regex
+      (path: string) => path.match(new RegExp(ROUTE));
 
-      return true;
-    };
 // pages on site to test
-const routes = allRoutes.filter(filter);
+const routes = allRoutes
+  .filter(filter)
+  // always ignore certain routes
+  .filter((path) => !path.endsWith(".xml"));
 
 export default routes;

--- a/tests/routes.ts
+++ b/tests/routes.ts
@@ -24,6 +24,9 @@ const filter =
               "/hilbert-curve",
               // no text
               "/laplace-transform",
+              // some posts
+              "/recommendations",
+              "/book-recommendations",
             ].some((p) => path.endsWith(p))
           )
             return true;

--- a/tests/routes.ts
+++ b/tests/routes.ts
@@ -1,13 +1,39 @@
 import allRoutes from "./routes.json" with { type: "json" };
 
 // by default, ignore less critical and numerous routes (like /lessons and /blog) to speed up tests
-const { ROUTE = "^(?!.*(\/lessons|\/blog))" } = process.env;
+const { ROUTE = "" } = process.env;
 
+// function to filter routes by
+const filter = ROUTE
+  ? // filter by provided regex
+    (path: string) => path.match(new RegExp(ROUTE))
+  : // default filter
+    (path: string) => {
+      if (path.endsWith(".xml")) return false;
+
+      // ignore less critical / more numerous routes to speed up tests
+      if (["/lessons", "/blog"].some((p) => path.startsWith(p))) {
+        // but still include representative sample of a few
+        if (
+          [
+            // large, popular, complex, math-only controls
+            "/essence-of-calculus",
+            // large, interactive
+            // interactive
+            "/newtons-fractal",
+            // no text, viz bg
+            "/hilbert-curve",
+            // no text
+            "/laplace-transform/",
+          ].some((p) => path.endsWith(p))
+        )
+          return true;
+        return false;
+      }
+
+      return true;
+    };
 // pages on site to test
-const routes = allRoutes
-  // always ignore some files
-  .filter((path) => !path.endsWith(".xml"))
-  // only test routes that match pattern
-  .filter((path) => path.match(new RegExp(ROUTE)));
+const routes = allRoutes.filter(filter);
 
 export default routes;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,8 +13,6 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import site from "./app/data/site.json";
 
 export default defineConfig(() => ({
-  // build: { assetsDir: "refresh" },
-
   // uncomment if cold-start refresh gets annoying
   // https://github.com/vitejs/vite/discussions/14801
   // optimizeDeps: {


### PR DESCRIPTION
- Rename "deep test" workflow to just "checks"
- Fix "test pr" report artifact upload
- Style tweaks
- Add debug logging to MathJax and wrap in try-catches
- Add "MathJax done" flag
- Topic cards 2-col even on smallest width device
- Make global error boundary native html elements only
- Disable MathJax completely in axe test
- Wait for "dom content loaded" (just doc + scripts) vs default "load" (doc + scripts + images/videos) in all e2e tests
- Remove useless "await Promise.all"
- Wait for MathJax done flag in math tests instead of static 5s
- Change e2e route specification mechanism, always include a few representative lesson/blog pages
- Disable retries, things should pass in 1 or we aren't listening for right ready signals
- Use default "50%" (of cores) for number of workers
- Add some chrome startup flags to possibly improve reliability
- Run e2e tests on production build instead of dev server, fixes random reloads due to vite repeatedly refreshing on cold start

In the current configuration I've re-run the tests on CI several times and they seem to be passing consistently now.
