### PR TITLE
Print script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+
+print

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,6 +1,9 @@
 import DarkMode from "~/components/DarkMode";
+import { usePrinting } from "~/util/hooks";
 
 export default function Footer() {
+  if (usePrinting()) return null;
+
   return (
     <footer className="dark z-20 flex items-center justify-between gap-8 bg-white p-8 font-sans text-black max-md:grid-cols-[auto_auto] print:hidden">
       <DarkMode />

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -7,6 +7,7 @@ import Logo from "~/components/Logo";
 import Nav from "~/components/Nav";
 import StrokeType from "~/components/StrokeType";
 import site from "~/data/site.json";
+import { usePrinting } from "~/util/hooks";
 
 type Props = {
   // background for header
@@ -24,6 +25,8 @@ export default function Header({
   background = defaultBackground,
   children,
 }: Props) {
+  if (usePrinting()) return null;
+
   return (
     <header
       className={clsx(

--- a/app/components/StrokeType.tsx
+++ b/app/components/StrokeType.tsx
@@ -1,4 +1,5 @@
 import type { ComponentProps } from "react";
+import { usePrinting } from "~/util/hooks";
 import classes from "./StrokeType.module.css";
 
 type Props = {
@@ -17,6 +18,8 @@ export default function StrokeType({
   children,
   ...props
 }: Props) {
+  if (usePrinting()) return children;
+
   const chars = children.split("");
 
   return (

--- a/app/components/TableOfContents.tsx
+++ b/app/components/TableOfContents.tsx
@@ -14,6 +14,7 @@ import { useAtomValue } from "jotai";
 import { headingsAtom } from "~/components/Heading";
 import Link from "~/components/Link";
 import { findClosest, firstInView, scrollTo } from "~/util/dom";
+import { usePrinting } from "~/util/hooks";
 
 // spacing between toc and section content
 const spacing = 60;
@@ -92,6 +93,8 @@ export default function TableOfContents() {
       // scroll active toc item into view
       scrollTo(activeRef.current, { behavior: "instant", block: "center" });
   });
+
+  if (usePrinting()) return null;
 
   // if only h1, no point in showing toc
   if (headings.length < 2) return null;

--- a/app/components/ViewCorner.tsx
+++ b/app/components/ViewCorner.tsx
@@ -1,9 +1,12 @@
 import Feedback from "~/components/Feedback";
 import Jump from "~/components/Jump";
 import Share from "~/components/Share";
+import { usePrinting } from "~/util/hooks";
 
 // small controls that hover in corner of screen
 export default function ViewCorner() {
+  if (usePrinting()) return null;
+
   const buttons = [
     ["Jump to top", <Jump />],
     ["Share page", <Share />],

--- a/app/styles.css
+++ b/app/styles.css
@@ -73,11 +73,11 @@
   }
 
   body {
-    @apply flex min-h-dvh flex-col;
+    @apply flex min-h-dvh flex-col print:block;
   }
 
   main {
-    @apply flex grow flex-col;
+    @apply flex grow flex-col print:block;
 
     &.striped > section:nth-of-type(odd) {
       @apply bg-alt-white;
@@ -85,7 +85,7 @@
   }
 
   section {
-    @apply width-md relative isolate flex break-before-page flex-col gap-(--gap) overflow-x-clip bg-white px-[max(var(--pad),(100%-(--spacing(1))*var(--width))/2)] py-(--pad) text-black [--gap:--spacing(12)] [--pad:--spacing(16)] last:grow max-md:[--gap:--spacing(8)] max-md:[--pad:--spacing(8)] print:bg-transparent! print:p-0;
+    @apply width-md relative isolate flex flex-col gap-(--gap) overflow-x-clip bg-white px-[max(var(--pad),(100%-(--spacing(1))*var(--width))/2)] py-(--pad) text-black [--gap:--spacing(12)] [--pad:--spacing(16)] not-first-of-type:break-before-page last:grow max-md:[--gap:--spacing(8)] max-md:[--pad:--spacing(8)] print:isolation-auto print:block print:overflow-visible print:bg-transparent! print:p-0 print:*:my-8;
   }
 
   hr {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "clean": "rm -rf node_modules dist bun.lock && bun pm cache rm",
     "check:spelling": "bunx cspell '**/*.{ts,tsx,mdx,md}' --dictionary lorem-ipsum  2>&1 | grep '.*fix:'",
     "check:unused": "bunx --bun knip --no-exit-code",
-    "check:links": "cd build/client && bunx linkinator './**/*.html' --recurse --clean-urls ; cd ../.."
+    "check:links": "cd build/client && bunx linkinator './**/*.html' --recurse --clean-urls ; cd ../..",
+    "print": "ROUTE=/3d bun run test:e2e print"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "test:types": "react-router typegen && tsc",
     "test:lint": "eslint .",
     "test:format": "prettier --check .",
-    "test:e2e": "playwright test",
+    "test:e2e": "playwright test --grep-invert print",
     "test": "bun run test:types && bun run test:lint && bun run test:format && bun run test:e2e && bun run build",
     "install-playwright": "bunx playwright install chromium --with-deps",
     "clean": "rm -rf node_modules dist bun.lock && bun pm cache rm",
     "check:spelling": "bunx cspell '**/*.{ts,tsx,mdx,md}' --dictionary lorem-ipsum  2>&1 | grep '.*fix:'",
     "check:unused": "bunx --bun knip --no-exit-code",
     "check:links": "cd build/client && bunx linkinator './**/*.html' --recurse --clean-urls ; cd ../..",
-    "print": "ROUTE=/3d bun run test:e2e print"
+    "print": "ROUTE=/lessons playwright test print"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/tests/math.spec.ts
+++ b/tests/math.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import routes from "./routes";
-import { log, stringify } from "./util";
+import { log, stringify, waitForMath } from "./util";
 
 log();
 
@@ -23,13 +23,8 @@ const checkPage = (route: string) =>
     // navigate to page
     await page.goto(route, { waitUntil: "domcontentloaded" });
 
-    // wait for mathjax to finish first load
-    await expect
-      // poll on node-side to avoid browser-side timer/raf throttling w/ waitForFunction
-      .poll(async () => page.evaluate(() => window.MathJaxState === true), {
-        timeout: 30 * 1000,
-      })
-      .toBe(true);
+    // wait for math to render
+    await waitForMath(page);
 
     test.info().annotations.push({
       type: "MathJax errors",

--- a/tests/print.spec.ts
+++ b/tests/print.spec.ts
@@ -1,6 +1,6 @@
 import test from "@playwright/test";
 import routes from "./routes";
-import { waitForMath } from "./util";
+import { waitForImages, waitForMath } from "./util";
 
 // not actually a "test", but run as one to produce printed pdfs as a side effect
 // more convenient than writing standalone script b/c we can use existing test infra
@@ -30,8 +30,8 @@ const printPage = (route: string) =>
     // wait for math to render
     await waitForMath(page);
 
-    // wait a bit extra for page to settle
-    await page.waitForTimeout(10000);
+    // wait for images to load
+    await waitForImages(page);
 
     // print pdf
     await page.pdf({

--- a/tests/print.spec.ts
+++ b/tests/print.spec.ts
@@ -1,0 +1,47 @@
+import test from "@playwright/test";
+import routes from "./routes";
+import { waitForMath } from "./util";
+
+// not actually a "test", but run as one to produce printed pdfs as a side effect
+// more convenient than writing standalone script b/c we can use existing test infra
+
+// us letter size, in css units
+const width = 8.5 * 96;
+const height = 11 * 96;
+const margin = 0.5 * 96;
+
+const printPage = (route: string) =>
+  test(`Print page "${route}"`, async ({ browserName, page }) => {
+    // test should be independent of browser, so only run one
+    test.skip(browserName !== "chromium", "Only test on chromium");
+
+    // test can be slow
+    test.setTimeout(60 * 1000);
+
+    // navigate to page
+    await page.goto(route);
+
+    // wait for app to render
+    await page.emulateMedia({ media: "print" });
+
+    // force page resize event for e.g. auto-resizing elements
+    await page.setViewportSize({ width, height });
+
+    // wait for math to render
+    await waitForMath(page);
+
+    // wait a bit extra for page to settle
+    await page.waitForTimeout(10000);
+
+    // print pdf
+    await page.pdf({
+      path: `print/${route}.pdf`,
+      format: "letter",
+      width,
+      height,
+      margin: { top: margin, bottom: margin, left: margin, right: margin },
+    });
+  });
+
+// print all pages
+routes.map(printPage);

--- a/tests/routes.ts
+++ b/tests/routes.ts
@@ -45,3 +45,5 @@ const routes = allRoutes
   .filter((path) => !path.endsWith(".xml"));
 
 export default routes;
+
+export { allRoutes };

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import test from "@playwright/test";
 
 // wait ms
@@ -14,3 +15,12 @@ export const log = () => {
       page.on("console", (msg) => console.info(msg.text())),
     );
 };
+
+// wait for mathjax to finish first load
+export const waitForMath = (page: Page) =>
+  test.expect
+    // poll on node-side to avoid browser-side timer/raf throttling w/ waitForFunction
+    .poll(async () => page.evaluate(() => window.MathJaxState === true), {
+      timeout: 30 * 1000,
+    })
+    .toBe(true);

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -24,3 +24,18 @@ export const waitForMath = (page: Page) =>
       timeout: 30 * 1000,
     })
     .toBe(true);
+
+// wait for images to fully load
+export const waitForImages = (page: Page) =>
+  test.expect
+    // poll on node-side to avoid browser-side timer/raf throttling w/ waitForFunction
+    .poll(
+      async () =>
+        page.evaluate(() =>
+          Array.from(document.querySelectorAll("img")).every(
+            (img) => img.complete,
+          ),
+        ),
+      { timeout: 30 * 1000 },
+    )
+    .toBe(true);


### PR DESCRIPTION
#556

- use `usePrinting` hook in addition to `print:hidden` where appropriate. mostly inconsequential, but might make layout bugs slightly less likely by removing the element completely instead of hiding with css. and makes page rendering slightly faster.
- change display `flex` to `block` for certain elements when printing, because Chrome gets thrown off when using `flex` and page breaks when printing. Firefox and Safari handle it fine, so if some day we want to keep the precise-ness of flex spacing in the prints and are okay with having to locally install those browsers, we can get rid of the `print:block` overrides.
- extract `waitForMath` to test util. add `waitForImages` test util. technically it's not really testing anything, but it's way more convenient to implement it as a test: can use existing test utils, playwright will handle concurrency and browser setup/teardown, etc.
- add new "test" that prints pages to pdfs using the playwright test infrastructure
- add new `bun run print` command to print lesson pages.