### PR TITLE
Fix typo in Feedback component label.

### DIFF
--- a/app/components/Feedback.tsx
+++ b/app/components/Feedback.tsx
@@ -214,7 +214,8 @@ export default function Feedback() {
 
               <CheckBox required form={id} className="col-span-full">
                 <span>
-                  My message is about this site and is not addressed by the FAQs
+                  My message is about this site and is not addressed by any of
+                  the FAQs
                 </span>
               </CheckBox>
 


### PR DESCRIPTION
## Summary

Corrected incomplete checkbox copy in the Feedback form so it matches the phrasing used on the About page contact form. The checkbox previously read “…is not addressed by the FAQs”; it now reads “…is not addressed by any of the FAQs,” which is clearer and consistent with `Contact.tsx`.

Verified with `git status`, `npm run lint`, and `npm run build`. No backend, config, test, or unrelated files were touched. README.md was unchanged (typo not present there).

## Testing

- Commands run:
- `git status`
- `npm run lint`
- `npm run build`
- Results:
- `git status`: only `app/components/Feedback.tsx` committed; working tree clean after commit
- `npm run lint`: passed (0 errors; 1 pre-existing warning in `.github/get-stats.ts`)
- `npm run build`: passed

## Implementation notes

- **Before:** `My message is about this site and is not addressed by the FAQs`
- **After:** `My message is about this site and is not addressed by any of the FAQs`
- Copy-only change in the required checkbox label text; no logic, layout, styling, or component structure changes.
- Matches the established FAQ attestation wording in `app/pages/about/Contact.tsx`: “My message is not addressed by any of the FAQs”.
- Form.tsx and README.md were reviewed; no shared-label typo found outside Feedback.tsx.

## Suggested follow-ups

- Consider a brief copy pass across form attestation strings to keep FAQ-related checkbox wording identical everywhere users must confirm they read the FAQs.
- You may want to review FAQ-related attestation copy across all user-facing forms for total consistency.
- Consider introducing shared constants for form attestation strings to reduce future microcopy drift.

## Notes for reviewers

I verified that only app/components/Feedback.tsx was modified, specifically updating the FAQ attestation label to 'is not addressed by any of the FAQs' for consistency with Contact.tsx and improved clarity. Lint and build passed with no errors, the working tree remained clean, and no additional files (including README.md or Form.tsx) needed adjustments. No backend or logic changes were made.

— [RGConsulting12](https://github.com/RGConsulting12)