### PR TITLE
Update redirects

### DIFF
--- a/app/pages/NotFound.tsx
+++ b/app/pages/NotFound.tsx
@@ -1,5 +1,3 @@
-import type { Route } from "./+types/NotFound";
-import { redirect } from "react-router";
 import Footer from "~/components/Footer";
 import Header from "~/components/Header";
 import { H1 } from "~/components/Heading";
@@ -8,29 +6,7 @@ import Meta from "~/components/Meta";
 import PiCreature from "~/components/PiCreature";
 import StrokeType from "~/components/StrokeType";
 
-// redirects with regex capture groups (simple path redirects live in netlify.toml)
-const redirects: Record<string, string> = {
-  "/topics/(.+)": "/?topic=$1",
-};
-
-export const clientLoader = async ({ request }: Route.LoaderArgs) => {
-  const { pathname } = new URL(request.url);
-
-  // client-side redirect
-  for (let [pattern, destination] of Object.entries(redirects)) {
-    const regex = new RegExp(`^${pattern}/?$`);
-    // matching redirect
-    const match = pathname.match(regex);
-    if (!match) continue;
-    // replace $1, $2, etc. with regex capture groups
-    destination = destination.replace(
-      /\$(\d+)/g,
-      (_, index) => match[Number(index)] ?? "",
-    );
-    // redirect to destination
-    throw redirect(destination);
-  }
-};
+// path redirects (including /topics/* → /?topic=) live in netlify.toml
 
 // 404 not found page
 export default function NotFound() {

--- a/app/pages/NotFound.tsx
+++ b/app/pages/NotFound.tsx
@@ -41,6 +41,7 @@ const redirects: Record<string, string> = {
   "/nn": "/?topic=neural-networks",
   "/calculus": "/?topic=calculus",
   "/eoc": "/?topic=calculus",
+  "/janestreet": "/talent/janestreet",
 };
 
 export const clientLoader = async ({ request }: Route.LoaderArgs) => {

--- a/app/pages/NotFound.tsx
+++ b/app/pages/NotFound.tsx
@@ -8,40 +8,9 @@ import Meta from "~/components/Meta";
 import PiCreature from "~/components/PiCreature";
 import StrokeType from "~/components/StrokeType";
 
-// redirects
+// redirects with regex capture groups (simple path redirects live in netlify.toml)
 const redirects: Record<string, string> = {
-  "/faq": "/about#faqs",
-  "/faqs": "/about#faqs",
-  "/contact": "/about#contact",
-  "/blog": "/extras#blog",
-  "/podcast": "/extras#podcast",
-  "/home": "/",
-  "/lessons": "/",
   "/topics/(.+)": "/?topic=$1",
-  "/video": "/",
-  "/live": "/",
-  "/store": "https://store.dftba.com/collections/3blue1brown",
-  "/plushie": "/store",
-  "/thanks": "/about#thanks",
-  "/recommendations": "/blog/recommendations",
-  "/some1-results": "/blog/some1-results",
-  "/poems": "/blog/poems",
-  "/videos": "https://www.youtube.com/3blue1brown",
-  "/support": "https://www.patreon.com/3blue1brown",
-  "/early-attention": "https://www.patreon.com/3blue1brown",
-  "/subscribe": "https://www.youtube.com/c/3blue1brown?sub_confirmation=1",
-  "/brilliant": "https://brilliant.org/3b1b",
-  "/quaternion-explorable": "https://eater.net/quaternions",
-  "/mail": "https://3blue1brown.substack.com/",
-  "/some": "https://some.3b1b.co",
-  "/some1": "https://some.3b1b.co",
-  "/recommended": "/?topic=best-of",
-  "/eola": "/?topic=linear-algebra",
-  "/neural-networks": "/?topic=neural-networks",
-  "/nn": "/?topic=neural-networks",
-  "/calculus": "/?topic=calculus",
-  "/eoc": "/?topic=calculus",
-  "/janestreet": "/talent/janestreet",
 };
 
 export const clientLoader = async ({ request }: Route.LoaderArgs) => {

--- a/netlify.toml
+++ b/netlify.toml
@@ -36,6 +36,164 @@ to = "https://www.3blue1brown.com/:splat"
 status = 301
 force = true
 
+# path redirects (vanity URLs, moved pages, external destinations)
+# note: regex-with-capture redirects (e.g. /topics/:topic) stay in app/pages/NotFound.tsx
+
+[[redirects]]
+from = "/faq"
+to = "/about#faqs"
+status = 301
+
+[[redirects]]
+from = "/faqs"
+to = "/about#faqs"
+status = 301
+
+[[redirects]]
+from = "/contact"
+to = "/about#contact"
+status = 301
+
+[[redirects]]
+from = "/blog"
+to = "/extras#blog"
+status = 301
+
+[[redirects]]
+from = "/podcast"
+to = "/extras#podcast"
+status = 301
+
+[[redirects]]
+from = "/home"
+to = "/"
+status = 301
+
+[[redirects]]
+from = "/lessons"
+to = "/"
+status = 301
+
+[[redirects]]
+from = "/video"
+to = "/"
+status = 301
+
+[[redirects]]
+from = "/live"
+to = "/"
+status = 301
+
+[[redirects]]
+from = "/store"
+to = "https://store.dftba.com/collections/3blue1brown"
+status = 301
+
+[[redirects]]
+from = "/plushie"
+to = "/store"
+status = 301
+
+[[redirects]]
+from = "/thanks"
+to = "/about#thanks"
+status = 301
+
+[[redirects]]
+from = "/recommendations"
+to = "/blog/recommendations"
+status = 301
+
+[[redirects]]
+from = "/some1-results"
+to = "/blog/some1-results"
+status = 301
+
+[[redirects]]
+from = "/poems"
+to = "/blog/poems"
+status = 301
+
+[[redirects]]
+from = "/videos"
+to = "https://www.youtube.com/3blue1brown"
+status = 301
+
+[[redirects]]
+from = "/support"
+to = "https://www.patreon.com/3blue1brown"
+status = 301
+
+[[redirects]]
+from = "/early-attention"
+to = "https://www.patreon.com/3blue1brown"
+status = 301
+
+[[redirects]]
+from = "/subscribe"
+to = "https://www.youtube.com/c/3blue1brown?sub_confirmation=1"
+status = 301
+
+[[redirects]]
+from = "/brilliant"
+to = "https://brilliant.org/3b1b"
+status = 301
+
+[[redirects]]
+from = "/quaternion-explorable"
+to = "https://eater.net/quaternions"
+status = 301
+
+[[redirects]]
+from = "/mail"
+to = "https://3blue1brown.substack.com/"
+status = 301
+
+[[redirects]]
+from = "/some"
+to = "https://some.3b1b.co"
+status = 301
+
+[[redirects]]
+from = "/some1"
+to = "https://some.3b1b.co"
+status = 301
+
+[[redirects]]
+from = "/recommended"
+to = "/?topic=best-of"
+status = 301
+
+[[redirects]]
+from = "/eola"
+to = "/?topic=linear-algebra"
+status = 301
+
+[[redirects]]
+from = "/neural-networks"
+to = "/?topic=neural-networks"
+status = 301
+
+[[redirects]]
+from = "/nn"
+to = "/?topic=neural-networks"
+status = 301
+
+[[redirects]]
+from = "/calculus"
+to = "/?topic=calculus"
+status = 301
+
+[[redirects]]
+from = "/eoc"
+to = "/?topic=calculus"
+status = 301
+
+[[redirects]]
+from = "/janestreet"
+to = "/talent/janestreet"
+status = 301
+
 [[redirects]]
 from = "/*"
 to = "/404"

--- a/netlify.toml
+++ b/netlify.toml
@@ -31,18 +31,6 @@ status = 301
 force = true
 
 [[redirects]]
-from = "https://3b1b.com/*"
-to = "https://www.3blue1brown.com/:splat"
-status = 301
-force = true
-
-[[redirects]]
-from = "https://www.3b1b.com/*"
-to = "https://www.3blue1brown.com/:splat"
-status = 301
-force = true
-
-[[redirects]]
 from = "https://3blue1brown.com/*"
 to = "https://www.3blue1brown.com/:splat"
 status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -195,6 +195,11 @@ to = "/talent/janestreet"
 status = 301
 
 [[redirects]]
+from = "/topics/*"
+to = "/?topic=:splat"
+status = 301
+
+[[redirects]]
 from = "/*"
 to = "/404"
 status = 404


### PR DESCRIPTION
Currently redirects only fire after a request falls through to the 404 page. This moves most redirects back to the netlify.toml page, which returns 301s, run before the /* → /404 fallback


@vincerubinetti, I wanted to get your read here, since I can tell you moved things deliberately. Am I right, it's because of the regex resolutions, combined with a desire for a single source of truth?

This was based on a conversation with Claude, which listed these downsides to the present approach:

  - Not a real redirect. Search engines and crawlers see a 404 status, not a 301/302. Link equity isn't passed, and these URLs may get deindexed. For a high-traffic site where people share links like /janestreet, that matters.
  - Requires JS + a flash. A user with JS disabled, or on a slow connection, lands on the "Not Found" page (or sees it flash) before the redirect happens. Bots without JS just see the 404.
  - Coupling. Redirect logic lives inside the 404 component, which is a bit surprising as a place to look.