### PR TITLE
Fixed basis vector references in Cramer's Rule explanation

### DIFF
--- a/app/pages/lessons/2019/cramers-rule/index.mdx
+++ b/app/pages/lessons/2019/cramers-rule/index.mdx
@@ -253,7 +253,7 @@ $$
   answer={4}
 >
 
-Solve for the $x$-coordinate of the vector by calculating the area of the parallelogram formed by the transformed $\hat{\imath}$ and output vector and then dividing by the determinant of the matrix.
+Solve for the $x$-coordinate of the vector by calculating the area of the parallelogram formed by the transformed $\hat{\jmath}$ and output vector and then dividing by the determinant of the matrix.
 
 $$
 \begin{aligned}
@@ -271,7 +271,7 @@ x & =\frac{\text { Area }}{\operatorname{det}(A)} \\ \rule{0pt}{3.5em}
 \end{aligned}
 $$
 
-Solve for the $y$-coordinate of the vector by calculating the area of the parallelogram formed by the transformed $\hat{\jmath}$ and output vector and then dividing by the determinant of the matrix.
+Solve for the $y$-coordinate of the vector by calculating the area of the parallelogram formed by the transformed $\hat{\imath}$ and output vector and then dividing by the determinant of the matrix.
 
 $$
 \begin{aligned}
@@ -301,7 +301,7 @@ The input vector that satisfies the linear system described by $\left[\begin{arr
   answer={4}
 >
 
-Solve for the $x$-coordinate of the vector by calculating the area of the parallelogram formed by the transformed $\hat{\imath}$ and output vector and then dividing by the determinant of the matrix.
+Solve for the $x$-coordinate of the vector by calculating the area of the parallelogram formed by the transformed $\hat{\jmath}$ and output vector and then dividing by the determinant of the matrix.
 
 $$
 \begin{aligned}
@@ -318,7 +318,7 @@ x & =\frac{\text { Area }}{\operatorname{det}(A)} \\ \rule{0pt}{3.5em}
 \end{aligned}
 $$
 
-Solve for the $y$-coordinate of the vector by calculating the area of the parallelogram formed by the transformed $\hat{\jmath}$ and output vector and then dividing by the determinant of the matrix.
+Solve for the $y$-coordinate of the vector by calculating the area of the parallelogram formed by the transformed $\hat{\imath}$ and output vector and then dividing by the determinant of the matrix.
 
 $$
 \begin{aligned}


### PR DESCRIPTION
The current text states that the x-coordinate's numerator is the area of the parallelogram formed by the transformed î and the output vector, and that the y-coordinate's numerator uses transformed ĵ and the output vector. This is backwards.
Since b = x·(transformed î) + y·(transformed ĵ), pairing the output vector with transformed ĵ isolates x (the transformed î component's contribution to that area is zero), and pairing it with transformed î isolates y. This matches the determinants actually used later in the lesson/example (e.g. keeping the ĵ-column fixed when solving for x).