### PR TITLE
Add tag support for talent partners

### DIFF
--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -29,7 +29,7 @@ export default function Card({
     <Link
       arrow={false}
       className={clsx(
-        "group relative isolate grid rounded-md text-black no-underline outline-none hocus:scale-101",
+        "group relative isolate grid rounded-md text-black no-underline outline-none hocus:scale-102",
         direction === "row"
           ? "grid-cols-3 gap-8 max-md:grid-cols-2 max-sm:grid-cols-1"
           : "grid-cols-1 content-start gap-4 text-center text-balance",

--- a/app/components/Footnote.tsx
+++ b/app/components/Footnote.tsx
@@ -6,7 +6,13 @@ type Props = ComponentProps<"a">;
 // custom footnote component to replace markdown footnote links
 export default function Footnote({ href, children }: Props) {
   return (
-    <Tooltip trigger={<button className="badge size-4">{children}</button>}>
+    <Tooltip
+      trigger={
+        <button className="size-4 rounded-full bg-theme text-white">
+          {children}
+        </button>
+      }
+    >
       <div
         ref={(element) => {
           if (!element || !href) return;

--- a/app/pages/home/Theater.tsx
+++ b/app/pages/home/Theater.tsx
@@ -122,7 +122,11 @@ export default function Theater() {
           {/* title */}
           <div className="font-sans text-lg">
             {lesson?.title}
-            {lesson?.id === latest?.id && <sup className="badge">New</sup>}
+            {lesson?.id === latest?.id && (
+              <sup className="ml-1 rounded-full bg-theme/25 px-1 text-theme">
+                New
+              </sup>
+            )}
           </div>
 
           {/* actions */}

--- a/app/pages/talent/Partner.tsx
+++ b/app/pages/talent/Partner.tsx
@@ -13,6 +13,7 @@ type RawPartnerFrontmatter = {
   tagline?: string;
   quote?: string;
   color?: string;
+  tags?: string[];
 };
 
 // partner import (before any transformation)
@@ -60,7 +61,7 @@ export default function Partner({ params: { id } }: Route.ComponentProps) {
       <PartnerHeader />
 
       <Main className="striped">
-        <H1 className="sr-only">Jane Street</H1>
+        <H1 className="sr-only">{name}</H1>
         <Component />
       </Main>
 

--- a/app/pages/talent/Partners.tsx
+++ b/app/pages/talent/Partners.tsx
@@ -5,6 +5,7 @@ import { useDarkMode } from "~/components/DarkMode";
 import { H2 } from "~/components/Heading";
 import { seededShuffle } from "~/util/math";
 import { getLogo, getLogoDark, getPartner } from "./Partner";
+import Tags from "./Tags";
 
 const partners: [string, ...string[]] = [
   "janestreet",
@@ -47,7 +48,7 @@ export default function Partners() {
         {order.map((id) => {
           const partner = getPartner(id);
           if (!partner) return null;
-          const { name = "", tagline = "" } = partner.frontmatter;
+          const { name = "", tagline = "", tags = [] } = partner.frontmatter;
           const logo = getLogo(id) ?? "";
           const logoDark = getLogoDark(id) ?? "";
           return (
@@ -63,6 +64,7 @@ export default function Partners() {
               <div className="text-center text-balance text-gray">
                 {tagline}
               </div>
+              <Tags tags={tags} className="mt-2 text-sm" />
             </Card>
           );
         })}

--- a/app/pages/talent/Tags.tsx
+++ b/app/pages/talent/Tags.tsx
@@ -1,0 +1,25 @@
+import clsx from "clsx";
+
+type Props = {
+  tags?: string[];
+  className?: string;
+};
+
+export default function Tags({ tags, className }: Props) {
+  if (!tags?.length) return null;
+
+  return (
+    <div
+      className={clsx(
+        "flex flex-wrap justify-center gap-2 font-sans",
+        className,
+      )}
+    >
+      {tags.map((tag, index) => (
+        <span key={index} className="rounded-full bg-theme/35 px-2">
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/app/pages/talent/janestreet/index.mdx
+++ b/app/pages/talent/janestreet/index.mdx
@@ -2,9 +2,6 @@
 name: Jane Street
 tagline: Quantitative trading and technology
 quote: Everybody here is a math nerd. If you go up to someone and start explaining a math puzzle, they'll stop you before you can tell them how to solve it because they want to try it on their own.
-tags:
-  - Remote Available
-  - Visa Available
 ---
 
 import { ArrowUpRightIcon } from "@phosphor-icons/react";
@@ -24,7 +21,6 @@ import polyhedralDesktop from "./polyhedral-desktop.jpg";
 import polyhedralMobile from "./polyhedral-mobile.jpg";
 import whiteboardWide from "./whiteboard-wide.jpg";
 import wordmark from "./wordmark.svg";
-import Tags from "../Tags";
 
 <section className="dark width-lg">
 
@@ -46,8 +42,6 @@ import Tags from "../Tags";
   Explore Open Roles
   <ArrowUpRightIcon />
 </Button>
-
-<Tags tags={frontmatter.tags} />
 
 </section>
 

--- a/app/pages/talent/janestreet/index.mdx
+++ b/app/pages/talent/janestreet/index.mdx
@@ -2,6 +2,9 @@
 name: Jane Street
 tagline: Quantitative trading and technology
 quote: Everybody here is a math nerd. If you go up to someone and start explaining a math puzzle, they'll stop you before you can tell them how to solve it because they want to try it on their own.
+tags:
+  - Remote Available
+  - Visa Available
 ---
 
 import { ArrowUpRightIcon } from "@phosphor-icons/react";
@@ -21,6 +24,7 @@ import polyhedralDesktop from "./polyhedral-desktop.jpg";
 import polyhedralMobile from "./polyhedral-mobile.jpg";
 import whiteboardWide from "./whiteboard-wide.jpg";
 import wordmark from "./wordmark.svg";
+import Tags from "../Tags";
 
 <section className="dark width-lg">
 
@@ -42,6 +46,8 @@ import wordmark from "./wordmark.svg";
   Explore Open Roles
   <ArrowUpRightIcon />
 </Button>
+
+<Tags tags={frontmatter.tags} />
 
 </section>
 

--- a/app/styles.css
+++ b/app/styles.css
@@ -52,7 +52,7 @@
   --color-black: oklch(100% 0 240);
   --color-dark-gray: oklch(80% 0 240);
   --color-gray: oklch(60% 0 240);
-  --color-light-gray: oklch(20% 0 240);
+  --color-light-gray: oklch(22% 0 240);
   --color-alt-white: oklch(15% 0 240);
   --color-white: oklch(0% 0 240);
 
@@ -261,10 +261,6 @@
 
 @utility change-ring {
   @apply outline-2 outline-offset-2 outline-transparent;
-}
-
-@utility badge {
-  @apply bg-theme mx-1 rounded-full px-1 font-sans text-white;
 }
 
 @utility playing-fade {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,6 @@
 
   // check mdx in editor
   "mdx": {
-    "checkMdx": true,
-    "plugins": ["remark-math"]
+    "plugins": ["remark-frontmatter", "remark-mdx-frontmatter", "remark-math"]
   }
 }


### PR DESCRIPTION
- add `tags` as field on partner mdx files
- remove badge css util, simple enough to just do in place
- show tags in main link buttons on partners page
- add example tags to Jane Street, add example of showing them on partner page itself