### PR TITLE
Feature interactives more

### DIFF
--- a/app/components/Interactive.tsx
+++ b/app/components/Interactive.tsx
@@ -1,7 +1,7 @@
 import type { ComponentType, LazyExoticComponent } from "react";
 import { Suspense, useRef } from "react";
 import { useLocation } from "react-router";
-import { CornersOutIcon, HandPointingIcon } from "@phosphor-icons/react";
+import { CornersOutIcon } from "@phosphor-icons/react";
 import { useFullscreen } from "@reactuses/core";
 import clsx from "clsx";
 import Button from "~/components/Button";
@@ -36,8 +36,16 @@ export default function Interactive<
   // wrap with controls
   if (controls)
     children = (
-      <div className="relative isolate flex flex-col gap-4">
-        <div className="absolute -inset-x-999 -inset-y-8 -z-10 bg-secondary/10" />
+      <div className="relative isolate flex flex-col gap-4 py-8">
+        <div className="absolute top-0 -z-10 h-full w-screen self-center bg-secondary/10">
+          <Button
+            className="absolute bottom-0 left-0"
+            onClick={toggleFullscreen}
+            aria-label="Toggle fullscreen"
+          >
+            <CornersOutIcon />
+          </Button>
+        </div>
         <div
           ref={ref}
           className={clsx(
@@ -46,16 +54,6 @@ export default function Interactive<
           )}
         >
           {children}
-        </div>
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex items-center gap-2 text-gray">
-            <HandPointingIcon />
-            Interactive
-          </div>
-          <Button onClick={toggleFullscreen} aria-label="Toggle fullscreen">
-            Fullscreen
-            <CornersOutIcon />
-          </Button>
         </div>
       </div>
     );

--- a/app/components/LessonLink.tsx
+++ b/app/components/LessonLink.tsx
@@ -23,7 +23,7 @@ export default function LessonLink({ id, className, children }: Props) {
   if (!lesson) return children;
 
   // get lesson details
-  const { title = "", description = "", read } = lesson;
+  const { title = "", description = "", readable } = lesson;
 
   // if just text, wrap in button to ensure accessibility
   if (!isValidElement(children))
@@ -49,7 +49,7 @@ export default function LessonLink({ id, className, children }: Props) {
               <PlayIcon />
               Watch
             </Button>
-            {read && (
+            {readable && (
               <Button to={href("/lessons/:id", { id })} color="light" size="sm">
                 <BookOpenTextIcon />
                 Read

--- a/app/pages/home/Lessons.tsx
+++ b/app/pages/home/Lessons.tsx
@@ -87,10 +87,13 @@ export function Search({ dialog = false, close = () => {} }) {
       async (worker: Remote<typeof FuzzyAPI>) => {
         // track analytics event
         analyticsEvent("lesson_search", { search: debouncedSearch });
-        return (await worker.search(
-          lessons,
-          debouncedSearch,
-        )) as typeof lessons;
+        return (await worker.search(lessons, debouncedSearch, [
+          "id",
+          "title",
+          "description",
+          "year",
+          "tags",
+        ])) as typeof lessons;
       },
       [lessons, debouncedSearch],
     ),
@@ -133,7 +136,7 @@ export function Search({ dialog = false, close = () => {} }) {
           <div className="grid w-full grid-cols-3 gap-8 max-sm:grid-cols-1">
             <Button
               to={{ search: mergeSearch(location.search, `topic=&search=`) }}
-              className="self-center justify-self-start max-md:justify-self-center"
+              className="self-center max-md:justify-self-center"
               onClick={() => {
                 // clear search so user doesn't forget they're filtering by search
                 setSearch("");
@@ -188,8 +191,8 @@ export function Search({ dialog = false, close = () => {} }) {
                   title = "",
                   description = "",
                   image = "",
-                  read,
-                  interactive,
+                  read = false,
+                  tags = [],
                 }) => {
                   // has video
                   const video = getLesson(id)?.frontmatter.video;
@@ -250,8 +253,8 @@ export function Search({ dialog = false, close = () => {} }) {
                           >
                             <BookOpenTextIcon />
                             Read
-                            {interactive && (
-                              <div className="absolute top-full left-1/2 -translate-x-1/2 text-xs text-theme">
+                            {tags.includes("interactive") && (
+                              <div className="absolute top-full left-1/2 -translate-x-1/2 text-xs text-secondary">
                                 Interactive!
                               </div>
                             )}

--- a/app/pages/home/Lessons.tsx
+++ b/app/pages/home/Lessons.tsx
@@ -8,7 +8,6 @@ import {
   BookOpenTextIcon,
   CaretDownIcon,
   CaretUpIcon,
-  HandPointingIcon,
   MagnifyingGlassIcon,
   PlayIcon,
   VideoCameraSlashIcon,
@@ -246,12 +245,16 @@ export function Search({ dialog = false, close = () => {} }) {
                           <Button
                             size="sm"
                             to={href("/lessons/:id", { id })}
-                            className="justify-self-start"
+                            className="relative justify-self-start"
                             onClick={close}
                           >
                             <BookOpenTextIcon />
                             Read
-                            {interactive && <HandPointingIcon />}
+                            {interactive && (
+                              <div className="absolute top-full left-1/2 -translate-x-1/2 text-xs text-theme">
+                                Interactive!
+                              </div>
+                            )}
                           </Button>
                         </div>
                       )}

--- a/app/pages/home/Lessons.tsx
+++ b/app/pages/home/Lessons.tsx
@@ -8,6 +8,8 @@ import {
   BookOpenTextIcon,
   CaretDownIcon,
   CaretUpIcon,
+  FunnelIcon,
+  HandPointingIcon,
   MagnifyingGlassIcon,
   PlayIcon,
   VideoCameraSlashIcon,
@@ -18,12 +20,14 @@ import { useAtom, useAtomValue } from "jotai";
 import { event as analyticsEvent } from "~/components/Analytics";
 import Button from "~/components/Button";
 import Card from "~/components/Card";
+import CheckBox from "~/components/CheckBox";
 import { H2 } from "~/components/Heading";
 import TextBox from "~/components/TextBox";
+import Tooltip from "~/components/Tooltip";
 import { setAutoplay } from "~/pages/home/Theater";
 import { byDate, getLesson } from "~/pages/lessons/lessons";
 import { topics } from "~/pages/lessons/topics";
-import { atomWithQuery, getAtom } from "~/util/atom";
+import { atomWithQuery, getAtom, setAtom } from "~/util/atom";
 import { preserveScroll, scrollTo } from "~/util/dom";
 import { useWorker } from "~/util/hooks";
 import { mergeSearch } from "~/util/url";
@@ -63,6 +67,11 @@ export function Search({ dialog = false, close = () => {} }) {
   // current topic details
   const topic = topicId in topics ? topics[topicId as TopicId] : undefined;
 
+  // fallback to topic
+  const fallbackTopic = () => {
+    if (!topic) setAtom(topicAtom, "all");
+  };
+
   // current lesson
   const lessonId = useAtomValue(lessonAtom);
 
@@ -80,6 +89,10 @@ export function Search({ dialog = false, close = () => {} }) {
   const [search, setSearch] = useAtom(searchAtom);
   const debouncedSearch = useDebounce(search.trim(), 300);
 
+  // other filters
+  const [interactive, setInteractive] = useState(false);
+  const [readable, setReadable] = useState(false);
+
   // search results
   let [results = []] = useWorker(
     FuzzyWorker,
@@ -87,15 +100,19 @@ export function Search({ dialog = false, close = () => {} }) {
       async (worker: Remote<typeof FuzzyAPI>) => {
         // track analytics event
         analyticsEvent("lesson_search", { search: debouncedSearch });
-        return (await worker.search(lessons, debouncedSearch, [
+        // filter by free text search
+        let results = (await worker.search(lessons, debouncedSearch, [
           "id",
           "title",
           "description",
-          "year",
-          "tags",
         ])) as typeof lessons;
+        // filter by other filters
+        if (readable) results = results.filter((lesson) => lesson.readable);
+        if (interactive)
+          results = results.filter((lesson) => lesson.interactive);
+        return results;
       },
-      [lessons, debouncedSearch],
+      [lessons, debouncedSearch, interactive, readable],
     ),
   );
 
@@ -117,21 +134,50 @@ export function Search({ dialog = false, close = () => {} }) {
 
   return (
     <>
-      <TextBox
-        ref={searchBox}
-        icon={<MagnifyingGlassIcon />}
-        value={search}
-        onChange={setSearch}
-        className="text-lg"
-        placeholder="Search..."
-        aria-controls="results"
-        autoComplete="off"
-      />
+      <div className="flex gap-4">
+        <TextBox
+          ref={searchBox}
+          icon={<MagnifyingGlassIcon />}
+          value={search}
+          onChange={setSearch}
+          className="grow text-lg"
+          placeholder="Search lessons..."
+          aria-controls="results"
+          autoComplete="off"
+        />
+        <Tooltip
+          hover={false}
+          trigger={
+            <Button aria-label="More lesson filters">
+              <FunnelIcon />
+            </Button>
+          }
+        >
+          <CheckBox
+            value={readable}
+            onChange={(value) => {
+              setReadable(value);
+              fallbackTopic();
+            }}
+          >
+            Readable
+          </CheckBox>
+          <CheckBox
+            value={interactive}
+            onChange={(value) => {
+              setInteractive(value);
+              fallbackTopic();
+            }}
+          >
+            Interactive
+          </CheckBox>
+        </Tooltip>
+      </div>
 
       {/* selected topic */}
       {topic && (
-        <div className="relative isolate flex flex-col items-center gap-8 py-4">
-          <div className="absolute -inset-x-999 inset-y-0 -z-10 bg-secondary/10" />
+        <div className="relative isolate flex flex-col items-center py-4">
+          <div className="absolute top-0 -z-10 h-full w-screen self-center bg-secondary/10" />
 
           <div className="grid w-full grid-cols-3 gap-8 max-sm:grid-cols-1">
             <Button
@@ -191,8 +237,8 @@ export function Search({ dialog = false, close = () => {} }) {
                   title = "",
                   description = "",
                   image = "",
-                  read = false,
-                  tags = [],
+                  readable,
+                  interactive,
                 }) => {
                   // has video
                   const video = getLesson(id)?.frontmatter.video;
@@ -238,26 +284,34 @@ export function Search({ dialog = false, close = () => {} }) {
                           </div>
                         )}
                       </Card>
-                      {read && (
+                      {(readable || interactive) && (
                         <div
                           className={clsx(
-                            "absolute bottom-1/2 left-full translate-x-8 translate-y-1/2 max-lg:contents",
+                            "absolute bottom-1/2 left-full w-max translate-x-8 translate-y-1/2 max-lg:contents",
                             dialog && "contents",
                           )}
                         >
                           <Button
                             size="sm"
                             to={href("/lessons/:id", { id })}
-                            className="relative justify-self-start"
+                            className="justify-self-start"
                             onClick={close}
                           >
-                            <BookOpenTextIcon />
-                            Read
-                            {tags.includes("interactive") && (
-                              <div className="absolute top-full left-1/2 -translate-x-1/2 text-xs text-secondary">
-                                Interactive!
-                              </div>
-                            )}
+                            {readable ? (
+                              <BookOpenTextIcon />
+                            ) : interactive ? (
+                              <HandPointingIcon />
+                            ) : null}
+                            <div
+                              className={clsx(
+                                "whitespace-nowrap",
+                                readable && interactive && "text-sm",
+                              )}
+                            >
+                              {[readable && "Read", interactive && "Interact"]
+                                .filter(Boolean)
+                                .join(" + ")}
+                            </div>
                           </Button>
                         </div>
                       )}

--- a/app/pages/home/Theater.tsx
+++ b/app/pages/home/Theater.tsx
@@ -89,9 +89,6 @@ export default function Theater() {
   // last lesson in list
   const last = lessonInTopic ? getLast(topicLessons)?.frontmatter : undefined;
 
-  // link to readable lesson
-  const readLink = lesson?.id ? href(`/lessons/:id`, { id: lesson?.id }) : "";
-
   // show video details
   const [details, setDetails] = useState(false);
 
@@ -131,8 +128,8 @@ export default function Theater() {
 
           {/* actions */}
           <div className="flex flex-wrap gap-4">
-            {lesson?.read && (
-              <Button size="sm" to={readLink}>
+            {lesson?.readable && lesson?.id && (
+              <Button size="sm" to={href(`/lessons/:id`, { id: lesson?.id })}>
                 <BookOpenTextIcon />
                 Read
               </Button>

--- a/app/pages/home/fuzzy.ts
+++ b/app/pages/home/fuzzy.ts
@@ -10,7 +10,14 @@ export const search = <Entry extends Record<string, unknown>>(
   const keys = [...new Set(list.flatMap((entry) => Object.keys(entry)))];
   // init searcher
   const searcher = new Fuse<unknown>(list, {
-    keys,
+    keys: [
+      ...keys,
+      // also let search match key names (e.g. "interactive")
+      {
+        name: "keys",
+        getFn: (entry) => Object.keys(entry as Entry).join(" "),
+      },
+    ],
     threshold: 0.2,
     ignoreLocation: true,
   });

--- a/app/pages/home/fuzzy.ts
+++ b/app/pages/home/fuzzy.ts
@@ -5,19 +5,11 @@ import Fuse from "fuse.js";
 export const search = <Entry extends Record<string, unknown>>(
   list: Entry[],
   search: string,
+  keys: string[],
 ) => {
-  // search all top level keys
-  const keys = [...new Set(list.flatMap((entry) => Object.keys(entry)))];
   // init searcher
-  const searcher = new Fuse<unknown>(list, {
-    keys: [
-      ...keys,
-      // also let search match key names (e.g. "interactive")
-      {
-        name: "keys",
-        getFn: (entry) => Object.keys(entry as Entry).join(" "),
-      },
-    ],
+  const searcher = new Fuse<Entry>(list, {
+    keys,
     threshold: 0.2,
     ignoreLocation: true,
   });

--- a/app/pages/lessons/2017/bitcoin/index.mdx
+++ b/app/pages/lessons/2017/bitcoin/index.mdx
@@ -7,7 +7,8 @@ source: _2017/crypto.py
 credits:
   - Lesson by Grant Sanderson
   - Text adaptation by Josh Pullen
-interactive: true
+tags:
+  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2017/bitcoin/index.mdx
+++ b/app/pages/lessons/2017/bitcoin/index.mdx
@@ -7,8 +7,6 @@ source: _2017/crypto.py
 credits:
   - Lesson by Grant Sanderson
   - Text adaptation by Josh Pullen
-tags:
-  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2017/hilbert-curve/index.mdx
+++ b/app/pages/lessons/2017/hilbert-curve/index.mdx
@@ -7,8 +7,6 @@ source: _2016/hilbert
 credits:
   - Lesson by Grant Sanderson
   - Interactive by Vincent Rubinetti
-tags:
-  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2017/hilbert-curve/index.mdx
+++ b/app/pages/lessons/2017/hilbert-curve/index.mdx
@@ -7,7 +7,8 @@ source: _2016/hilbert
 credits:
   - Lesson by Grant Sanderson
   - Interactive by Vincent Rubinetti
-interactive: true
+tags:
+  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2017/light-quantum-mechanics/index.mdx
+++ b/app/pages/lessons/2017/light-quantum-mechanics/index.mdx
@@ -8,8 +8,6 @@ source: _2017/waves.py
 credits:
   - Lesson by Grant Sanderson
   - Text Adaption by River Way
-tags:
-  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2017/light-quantum-mechanics/index.mdx
+++ b/app/pages/lessons/2017/light-quantum-mechanics/index.mdx
@@ -8,7 +8,8 @@ source: _2017/waves.py
 credits:
   - Lesson by Grant Sanderson
   - Text Adaption by River Way
-interactive: true
+tags:
+  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2017/neural-network-analysis/index.mdx
+++ b/app/pages/lessons/2017/neural-network-analysis/index.mdx
@@ -6,7 +6,8 @@ credits:
   - Lesson by Grant Sanderson
   - Text adaptation by Josh Pullen
 thumbnail: $lesson/thumbnail.jpg
-interactive: true
+tags:
+  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2017/neural-network-analysis/index.mdx
+++ b/app/pages/lessons/2017/neural-network-analysis/index.mdx
@@ -6,8 +6,6 @@ credits:
   - Lesson by Grant Sanderson
   - Text adaptation by Josh Pullen
 thumbnail: $lesson/thumbnail.jpg
-tags:
-  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2017/neural-networks/index.mdx
+++ b/app/pages/lessons/2017/neural-networks/index.mdx
@@ -8,8 +8,6 @@ source: _2017/nn/part1.py
 credits:
   - Lesson by Grant Sanderson
   - Text adaptation by Josh Pullen
-tags:
-  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2017/neural-networks/index.mdx
+++ b/app/pages/lessons/2017/neural-networks/index.mdx
@@ -8,7 +8,8 @@ source: _2017/nn/part1.py
 credits:
   - Lesson by Grant Sanderson
   - Text adaptation by Josh Pullen
-interactive: true
+tags:
+  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2018/fourier-transforms/index.mdx
+++ b/app/pages/lessons/2018/fourier-transforms/index.mdx
@@ -8,8 +8,6 @@ credits:
   - Lesson by Grant Sanderson
   - Text Adaption by James Schloss
   - Interactives by River Way
-tags:
-  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2018/fourier-transforms/index.mdx
+++ b/app/pages/lessons/2018/fourier-transforms/index.mdx
@@ -8,7 +8,8 @@ credits:
   - Lesson by Grant Sanderson
   - Text Adaption by James Schloss
   - Interactives by River Way
-interactive: true
+tags:
+  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2019/fourier-series-montage/index.mdx
+++ b/app/pages/lessons/2019/fourier-series-montage/index.mdx
@@ -7,7 +7,8 @@ source: _2019/diffyq/fourier_montage_scenes.py
 credits:
   - Lesson by Grant Sanderson
   - Interactive by Vincent Rubinetti
-interactive: true
+tags:
+  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2019/fourier-series-montage/index.mdx
+++ b/app/pages/lessons/2019/fourier-series-montage/index.mdx
@@ -7,8 +7,6 @@ source: _2019/diffyq/fourier_montage_scenes.py
 credits:
   - Lesson by Grant Sanderson
   - Interactive by Vincent Rubinetti
-tags:
-  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2019/hyperdarts/index.mdx
+++ b/app/pages/lessons/2019/hyperdarts/index.mdx
@@ -7,7 +7,8 @@ source: _2019/hyperdarts.py
 credits:
   - Lesson by Grant Sanderson
   - Text Adaption by River Way
-interactive: true
+tags:
+  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2019/hyperdarts/index.mdx
+++ b/app/pages/lessons/2019/hyperdarts/index.mdx
@@ -7,8 +7,6 @@ source: _2019/hyperdarts.py
 credits:
   - Lesson by Grant Sanderson
   - Text Adaption by River Way
-tags:
-  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2019/prime-spirals/index.mdx
+++ b/app/pages/lessons/2019/prime-spirals/index.mdx
@@ -7,8 +7,6 @@ source: _2019/spirals.py
 credits:
   - Lesson by Grant Sanderson
   - Text Adaption by River Way
-tags:
-  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2019/prime-spirals/index.mdx
+++ b/app/pages/lessons/2019/prime-spirals/index.mdx
@@ -7,7 +7,8 @@ source: _2019/spirals.py
 credits:
   - Lesson by Grant Sanderson
   - Text Adaption by River Way
-interactive: true
+tags:
+  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2021/holomorphic-dynamics/index.mdx
+++ b/app/pages/lessons/2021/holomorphic-dynamics/index.mdx
@@ -8,16 +8,12 @@ credits:
   - Lesson by Grant Sanderson
   - Interactive by Josh Pullen
   - Interactive by Vincent Rubinetti
-tags:
-  - interactive
 ---
 
 import { lazy } from "react";
 import Interactive from "~/components/Interactive";
 
 <section>
-
-This lesson currently has no text version. But in the meantime, please enjoy this interactive version of the scene at 6:57.
 
 <Interactive Component={lazy(() => import("./Mandelbrot.tsx"))} />
 

--- a/app/pages/lessons/2021/holomorphic-dynamics/index.mdx
+++ b/app/pages/lessons/2021/holomorphic-dynamics/index.mdx
@@ -8,7 +8,8 @@ credits:
   - Lesson by Grant Sanderson
   - Interactive by Josh Pullen
   - Interactive by Vincent Rubinetti
-interactive: true
+tags:
+  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2021/newtons-fractal/index.mdx
+++ b/app/pages/lessons/2021/newtons-fractal/index.mdx
@@ -8,7 +8,8 @@ credits:
   - Lesson by Grant Sanderson
   - Interactive by Josh Pullen
   - Interactive by Vincent Rubinetti
-interactive: true
+tags:
+  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2021/newtons-fractal/index.mdx
+++ b/app/pages/lessons/2021/newtons-fractal/index.mdx
@@ -8,16 +8,12 @@ credits:
   - Lesson by Grant Sanderson
   - Interactive by Josh Pullen
   - Interactive by Vincent Rubinetti
-tags:
-  - interactive
 ---
 
 import { lazy } from "react";
 import Interactive from "~/components/Interactive";
 
 <section>
-
-There is no text version of this lesson yet. But in the meantime, enjoy the following interactive version of Newton's fractal.
 
 <Interactive Component={lazy(() => import("./NewtonsFractal.jsx"))} />
 

--- a/app/pages/lessons/2024/inscribed-rect-v2/SketchPad.tsx
+++ b/app/pages/lessons/2024/inscribed-rect-v2/SketchPad.tsx
@@ -1,10 +1,4 @@
 import type { Dispatch, SetStateAction } from "react";
-import { useRef } from "react";
-import {
-  useElementSize,
-  useEventListener,
-  useMousePressed,
-} from "@reactuses/core";
 import { clamp } from "lodash-es";
 import Canvas from "~/components/Canvas";
 
@@ -16,37 +10,28 @@ type Props = {
 };
 
 export default function SketchPad({ points, setPoints }: Props) {
-  const ref = useRef<HTMLCanvasElement>(null);
-
-  const [width, height] = useElementSize(ref);
-
-  const [pressed] = useMousePressed(ref);
-
-  useEventListener("pointerdown", () => setPoints([]), ref);
-
-  useEventListener("pointermove", (event: PointerEvent) => {
-    if (!pressed) return;
-    if (!ref.current) return;
-    const { left, top, width, height } = ref.current.getBoundingClientRect();
-    let x = (event.clientX - left) / width - 0.5;
-    let y = (event.clientY - top) / height - 0.5;
-    x = clamp(x, -0.5, 0.5);
-    y = clamp(y, -0.5, 0.5);
-    setPoints((points) => [...points, [x, y]]);
-  });
-
   return (
     <div className="absolute top-0 left-0">
       <Canvas
-        ref={ref}
         className="size-50 cursor-crosshair touch-none bg-white"
-        render={(ctx) => {
+        onPointerDown={() => setPoints([])}
+        onPointerMove={({ currentTarget, clientX, clientY, buttons }) => {
+          if (!buttons) return;
+          const { left, top, width, height } =
+            currentTarget.getBoundingClientRect();
+          let x = (clientX - left) / width - 0.5;
+          let y = (clientY - top) / height - 0.5;
+          x = clamp(x, -0.5, 0.5);
+          y = clamp(y, -0.5, 0.5);
+          setPoints((points) => [...points, [x, y]]);
+        }}
+        render={(ctx, { width, height }) => {
           ctx.strokeStyle = "black";
           ctx.lineWidth = 2;
           ctx.beginPath();
           points.forEach(([x, y], index) => {
-            if (index === 0) ctx.moveTo(x * width * 2, y * height * 2);
-            else ctx.lineTo(x * width * 2, y * height * 2);
+            if (index === 0) ctx.moveTo(x * width, y * height);
+            else ctx.lineTo(x * width, y * height);
           });
           ctx.stroke();
         }}

--- a/app/pages/lessons/2024/inscribed-rect-v2/index.mdx
+++ b/app/pages/lessons/2024/inscribed-rect-v2/index.mdx
@@ -7,8 +7,6 @@ source: _2024/inscribed_rect
 credits:
   - Lesson by Grant Sanderson
   - Blog adaptation by Josh Pullen
-tags:
-  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/2024/inscribed-rect-v2/index.mdx
+++ b/app/pages/lessons/2024/inscribed-rect-v2/index.mdx
@@ -7,7 +7,8 @@ source: _2024/inscribed_rect
 credits:
   - Lesson by Grant Sanderson
   - Blog adaptation by Josh Pullen
-interactive: true
+tags:
+  - interactive
 ---
 
 import { lazy } from "react";

--- a/app/pages/lessons/lessons.ts
+++ b/app/pages/lessons/lessons.ts
@@ -18,7 +18,7 @@ export type RawLessonFrontmatter = {
   thumbnail?: string;
   combinedCredits?: Record<string, string[]>;
   read?: boolean;
-  interactive?: boolean;
+  tags?: string[];
 };
 
 // lesson import (before any transformation)
@@ -35,6 +35,8 @@ export const transformLesson = (lesson: RawLesson, id: string) => ({
     id,
     // parse date
     date: parseDate(lesson.frontmatter.date ?? ""),
+    // just year
+    year: parseDate(lesson.frontmatter.date ?? "")?.getFullYear(),
     // lookup thumbnail
     image: lesson.frontmatter.video?.trim()
       ? getThumbnail(lesson.frontmatter.video)

--- a/app/pages/lessons/lessons.ts
+++ b/app/pages/lessons/lessons.ts
@@ -17,8 +17,8 @@ export type RawLessonFrontmatter = {
   image?: string;
   thumbnail?: string;
   combinedCredits?: Record<string, string[]>;
-  read?: boolean;
-  tags?: string[];
+  readable?: boolean;
+  interactive?: boolean;
 };
 
 // lesson import (before any transformation)

--- a/app/pages/talent/janestreet/index.mdx
+++ b/app/pages/talent/janestreet/index.mdx
@@ -2,9 +2,6 @@
 name: Jane Street
 tagline: Quantitative trading and technology
 quote: Everybody here is a math nerd. If you go up to someone and start explaining a math puzzle, they'll stop you before you can tell them how to solve it because they want to try it on their own.
-tags:
-  - Remote Available
-  - Visa Available
 ---
 
 import { ArrowUpRightIcon } from "@phosphor-icons/react";
@@ -24,7 +21,6 @@ import polyhedralDesktop from "./polyhedral-desktop.jpg";
 import polyhedralMobile from "./polyhedral-mobile.jpg";
 import whiteboardWide from "./whiteboard-wide.jpg";
 import wordmark from "./wordmark.svg";
-import Tags from "../Tags";
 
 <section className="dark width-lg">
 
@@ -46,8 +42,6 @@ import Tags from "../Tags";
   Explore Open Roles
   <ArrowUpRightIcon />
 </Button>
-
-<Tags tags={frontmatter.tags} />
 
 </section>
 

--- a/app/pages/talent/janestreet/index.mdx
+++ b/app/pages/talent/janestreet/index.mdx
@@ -2,6 +2,9 @@
 name: Jane Street
 tagline: Quantitative trading and technology
 quote: Everybody here is a math nerd. If you go up to someone and start explaining a math puzzle, they'll stop you before you can tell them how to solve it because they want to try it on their own.
+tags:
+  - Remote Available
+  - Visa Available
 ---
 
 import { ArrowUpRightIcon } from "@phosphor-icons/react";
@@ -21,6 +24,7 @@ import polyhedralDesktop from "./polyhedral-desktop.jpg";
 import polyhedralMobile from "./polyhedral-mobile.jpg";
 import whiteboardWide from "./whiteboard-wide.jpg";
 import wordmark from "./wordmark.svg";
+import Tags from "../Tags";
 
 <section className="dark width-lg">
 
@@ -42,6 +46,8 @@ import wordmark from "./wordmark.svg";
   Explore Open Roles
   <ArrowUpRightIcon />
 </Button>
+
+<Tags tags={frontmatter.tags} />
 
 </section>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,8 +55,9 @@ const textReplacePlugin: Plugin = {
         source = [
           "---",
           frontmatter,
-          // append extras to frontmatter
-          `read: ${!!content.trim()}`,
+          // append extra derived props to frontmatter
+          `readable: ${content.trim().length > 500}`,
+          `interactive: ${content.includes("<Interactive")}`,
           "---",
           searchParams.has("frontmatter-only") ? "" : content,
         ].join("\n");


### PR DESCRIPTION
I forked this branch from #667, so diff will show changes from that PR as well until I rebase.

- change css approach to "ribbon" (full-screen-width bg color) in interactive and home page selected topic
- move interactive fullscreen button to corner of ribbon
- rename `read` to `readable` where appropriate
- only search lessons by specified keys
- add filter button next to lesson search box to filter by readable and interactive
- tweak display and text of read/interactive buttons next to lesson results
- just compute `interactive` field on lessons automatically, like `readable`
- fix regression i noticed in inscribed rect lesson interactive involving canvas component