### PR TITLE
fix form control "required" regression, fix select option dark mode

### DIFF
--- a/app/components/CheckBox.tsx
+++ b/app/components/CheckBox.tsx
@@ -13,8 +13,9 @@ type Props = {
   onChange?: (value: boolean) => void;
   // label content, optional if aria-label present
   children?: ReactNode;
-} & Pick<ComponentProps<"label">, "className"> &
-  Pick<ComponentProps<"input">, "required" | "name" | "form">;
+  // class on root
+  className?: string;
+} & Pick<ComponentProps<"input">, "required" | "name" | "form">;
 
 export default function CheckBox({
   help,
@@ -46,6 +47,7 @@ export default function CheckBox({
             setLocalValue(value);
             onChange?.(value);
           }}
+          required={required}
           {...props}
         />
         <Icon className="text-theme" />

--- a/app/components/Feedback.tsx
+++ b/app/components/Feedback.tsx
@@ -213,9 +213,7 @@ export default function Feedback() {
               />
 
               <CheckBox required form={id} className="col-span-full">
-                <span>
-                  My message is about this site and is not addressed by the FAQs
-                </span>
+                My message is about this site and is not addressed by the FAQs
               </CheckBox>
 
               <Alert type={status} className="col-span-full">

--- a/app/components/Select.tsx
+++ b/app/components/Select.tsx
@@ -70,10 +70,11 @@ export default function Select<O extends Option>({
               onChange?.(options[element.selectedIndex]!.value);
             }
           }}
+          required={required}
           {...props}
         >
           {options.map((option, index) => (
-            <option key={index} value={option.value}>
+            <option key={index} value={option.value} className="bg-light-gray">
               {option.label ?? option.value}
             </option>
           ))}

--- a/app/components/TextBox.tsx
+++ b/app/components/TextBox.tsx
@@ -82,6 +82,7 @@ export default function TextBox({
       style={{ paddingRight: sidePadding ? sidePadding : "" }}
       value={value}
       onChange={(event) => onChange?.(event.target.value)}
+      required={required}
       {...(props as Multi)}
     />
   ) : (
@@ -91,6 +92,7 @@ export default function TextBox({
       style={{ paddingRight: sidePadding ? sidePadding : "" }}
       value={value}
       onChange={(event) => onChange?.(event.target.value)}
+      required={required}
       {...(props as Single)}
     />
   );


### PR DESCRIPTION
Closes #674 

- fix regression i stupidly introduced in #639 where `required` prop is not passed to actual form control elements
- fix `<option>` text not being visible in dark mode on windows (doesn't show on macos because `<select>` there uses OS-native dropdown)