### PR TITLE
Talent page cleanup

### DIFF
--- a/app/components/Figure.tsx
+++ b/app/components/Figure.tsx
@@ -55,7 +55,7 @@ export default function Figure({
 
   // if both, show tabs
   return (
-    <Tabs defaultValue={show}>
+    <Tabs defaultIndex={show === "video" ? 1 : 0}>
       <Panel
         title={
           <>

--- a/app/components/Figure.tsx
+++ b/app/components/Figure.tsx
@@ -55,21 +55,27 @@ export default function Figure({
 
   // if both, show tabs
   return (
-    <Tabs
-      tabs={[
-        <>
-          <ImageIcon />
-          Image
-        </>,
-        <>
-          <VideoIcon />
-          Video
-        </>,
-      ]}
-      defaultValue={show}
-    >
-      <Panel>{imageElement}</Panel>
-      <Panel>{videoElement}</Panel>
+    <Tabs defaultValue={show}>
+      <Panel
+        title={
+          <>
+            <ImageIcon />
+            Image
+          </>
+        }
+      >
+        {imageElement}
+      </Panel>
+      <Panel
+        title={
+          <>
+            <VideoIcon />
+            Video
+          </>
+        }
+      >
+        {videoElement}
+      </Panel>
     </Tabs>
   );
 }

--- a/app/components/Tabs.tsx
+++ b/app/components/Tabs.tsx
@@ -6,6 +6,8 @@ import { omit } from "lodash-es";
 import Button from "~/components/Button";
 
 type Props = {
+  // default selected tab index
+  defaultIndex?: number;
   // tabs (titles and content)
   children?: ReactNode;
   // class on root
@@ -13,7 +15,12 @@ type Props = {
 } & Omit<_Tabs.Root.Props, "children">;
 
 // tabs
-export default function Tabs({ children, className, ...props }: Props) {
+export default function Tabs({
+  defaultIndex,
+  children,
+  className,
+  ...props
+}: Props) {
   /** filter out conditional or invalid elements */
   const panels = Children.toArray(children).filter(
     (child): child is ReactElement<PanelProps> =>
@@ -23,6 +30,7 @@ export default function Tabs({ children, className, ...props }: Props) {
   return (
     <_Tabs.Root
       className={clsx("flex flex-col items-center gap-4", className)}
+      defaultValue={defaultIndex}
       {...props}
     >
       {/* buttons */}

--- a/app/components/Tabs.tsx
+++ b/app/components/Tabs.tsx
@@ -1,24 +1,33 @@
 import type { ReactElement, ReactNode } from "react";
-import { Children, cloneElement } from "react";
+import { Children, cloneElement, isValidElement } from "react";
 import { Tabs as _Tabs } from "@base-ui/react";
 import clsx from "clsx";
+import { omit } from "lodash-es";
 import Button from "~/components/Button";
 
 type Props = {
-  // content of each tab
-  tabs: ReactNode[];
-  // content panels
-  children?: ReactElement<{ index: number } & _Tabs.Panel.Props>[];
+  // tabs (titles and content)
+  children?: ReactNode;
   // class on root
   className?: string;
 } & Omit<_Tabs.Root.Props, "children">;
 
 // tabs
-export default function Tabs({ tabs, children, className }: Props) {
+export default function Tabs({ children, className, ...props }: Props) {
+  /** filter out conditional or invalid elements */
+  const panels = Children.toArray(children).filter(
+    (child): child is ReactElement<PanelProps> =>
+      isValidElement(child) && child.type === Panel,
+  );
+
   return (
-    <_Tabs.Root className={clsx("flex flex-col items-center gap-4", className)}>
+    <_Tabs.Root
+      className={clsx("flex flex-col items-center gap-4", className)}
+      {...props}
+    >
+      {/* buttons */}
       <_Tabs.List className="relative flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
-        {tabs.map((tab, index) => (
+        {panels.map((panel, index) => (
           <_Tabs.Tab
             key={index}
             value={index}
@@ -26,24 +35,28 @@ export default function Tabs({ tabs, children, className }: Props) {
               <Button {...props} color="none" className="rounded-b-none" />
             )}
           >
-            {tab}
+            {panel.props.title}
           </_Tabs.Tab>
         ))}
         <_Tabs.Indicator className="absolute right-(--active-tab-right) bottom-(--active-tab-bottom) left-(--active-tab-left) h-0.5 rounded-md bg-theme transition-all" />
       </_Tabs.List>
-      {Children.map(children ?? [], (child, index) =>
-        cloneElement(child, { index }),
-      )}
+
+      {/* panels */}
+      {panels.map((panel, index) => cloneElement(panel, { index }))}
     </_Tabs.Root>
   );
 }
 
 type PanelProps = {
+  // tab button content
+  title: ReactNode;
   // index of child
   index?: number;
-} & Partial<_Tabs.Panel.Props>;
+} & Omit<Partial<_Tabs.Panel.Props>, "title" | "index">;
 
 // tab panel content
 export function Panel({ index, ...props }: PanelProps) {
-  return <_Tabs.Panel className="contents" {...props} value={index} />;
+  return (
+    <_Tabs.Panel className="contents" {...omit(props, "title")} value={index} />
+  );
 }

--- a/app/pages/talent/Gallery.tsx
+++ b/app/pages/talent/Gallery.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useEffect, useState } from "react";
 import { H2 } from "~/components/Heading";
 import { seededShuffle } from "~/util/math";
-import PartnerRow from "./PartnerRow";
+import PartnerTile from "./PartnerTile";
 
 const partners: [string, ...string[]] = [
   "janestreet",
@@ -16,7 +16,7 @@ const partners: [string, ...string[]] = [
 ];
 
 // gallery of partners
-export default function Partners() {
+export default function Gallery() {
   const [order, setOrder] = useState(partners);
 
   useEffect(
@@ -40,7 +40,7 @@ export default function Partners() {
 
       {order.map((id, index) => (
         <Fragment key={index}>
-          <PartnerRow id={id} />
+          <PartnerTile id={id} />
           {index < order.length - 1 && <hr />}
         </Fragment>
       ))}

--- a/app/pages/talent/PartnerTabs.tsx
+++ b/app/pages/talent/PartnerTabs.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import ShowPartial from "~/components/ShowPartial";
 import Tabs, { Panel } from "~/components/Tabs";
 import Vimeo from "~/components/Vimeo";
@@ -29,56 +28,43 @@ export default function PartnerTabs({ id, className }: Props) {
   const { default: Message } = getMessage(id) ?? {};
   const { default: Challenge } = getChallenge(id) ?? {};
 
-  const tabs: { label: string; content: ReactNode }[] = [];
-
   const hasVideo = !!(youtube || vimeo);
 
-  // interview with team or other video
-  if (hasVideo)
-    tabs.push({
-      label: "Meet the Team",
-      content: youtube ? (
-        <YouTube id={youtube} />
-      ) : (
-        <Vimeo id={vimeo} hash={vimeoHash} />
-      ),
-    });
-
-  // message from grant
-  if (Message)
-    tabs.push({
-      label: "Message from Grant",
-      content: (
-        // clicking over to this tab is already intent to read it
-        <ShowPartial defaultOpen={hasVideo}>
-          <Message />
-        </ShowPartial>
-      ),
-    });
-  else if (about)
-    tabs.push({
-      label: `About ${name}`,
-      content: <p>{about}</p>,
-    });
-
-  // technical challenge or puzzle
-  if (Challenge)
-    tabs.push({
-      label: "Challenge",
-      content: (
-        <div className="flex flex-col gap-8">
-          <Challenge />
-        </div>
-      ),
-    });
-
-  if (!tabs.length) return null;
+  if (!hasVideo && !Message && !about && !Challenge) return null;
 
   return (
-    <Tabs tabs={tabs.map((tab) => tab.label)} className={className}>
-      {tabs.map((tab, index) => (
-        <Panel key={index}>{tab.content}</Panel>
-      ))}
+    <Tabs className={className}>
+      {hasVideo && (
+        <Panel title="Meet the Team">
+          {youtube ? (
+            <YouTube id={youtube} />
+          ) : (
+            <Vimeo id={vimeo} hash={vimeoHash} />
+          )}
+        </Panel>
+      )}
+
+      {Message && (
+        <Panel title="Message from Grant">
+          {/* clicking over to this tab is already intent to read it */}
+          <ShowPartial defaultOpen={hasVideo}>
+            <Message />
+          </ShowPartial>
+        </Panel>
+      )}
+      {!Message && about && (
+        <Panel title={`About ${name}`}>
+          <p>{about}</p>
+        </Panel>
+      )}
+
+      {Challenge && (
+        <Panel title="Challenge">
+          <div className="flex flex-col gap-8">
+            <Challenge />
+          </div>
+        </Panel>
+      )}
     </Tabs>
   );
 }

--- a/app/pages/talent/PartnerTile.tsx
+++ b/app/pages/talent/PartnerTile.tsx
@@ -49,7 +49,7 @@ export default function PartnerTile({ id }: Props) {
   return (
     <div className="flex gap-12 max-md:flex-col">
       {/* identity, high level details */}
-      <div className="flex flex-2 flex-col items-center justify-center gap-6 text-center md:h-92">
+      <div className="flex flex-2 flex-col items-center gap-6 text-center md:mt-16">
         <Link
           to={page}
           className="flex rounded-md text-black no-underline change-ring hocus:outline-theme"

--- a/app/pages/talent/PartnerTile.tsx
+++ b/app/pages/talent/PartnerTile.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import { href } from "react-router";
 import { ArrowUpRightIcon } from "@phosphor-icons/react";
 import Button from "~/components/Button";
@@ -47,42 +46,6 @@ export default function PartnerTile({ id }: Props) {
 
   const hasVideo = !!(youtube || vimeo);
 
-  const tabs: { label: string; content: ReactNode }[] = [];
-
-  // interview with team or other video
-  if (hasVideo)
-    tabs.push({
-      label: "Meet the Team",
-      content: youtube ? (
-        <YouTube id={youtube} />
-      ) : (
-        <Vimeo id={vimeo} hash={vimeoHash} />
-      ),
-    });
-
-  // message from grant
-  if (Message)
-    tabs.push({
-      label: "Message from Grant",
-      content: <Message />,
-    });
-  else if (about)
-    tabs.push({
-      label: `About ${name}`,
-      content: <p>{about}</p>,
-    });
-
-  // technical challenge or puzzle
-  if (Challenge)
-    tabs.push({
-      label: "Challenge",
-      content: (
-        <div className="flex flex-col gap-8">
-          <Challenge />
-        </div>
-      ),
-    });
-
   return (
     <div className="flex gap-12 max-md:flex-col">
       {/* identity, high level details */}
@@ -121,10 +84,35 @@ export default function PartnerTile({ id }: Props) {
       </div>
 
       {/* rich content, more details */}
-      <Tabs tabs={tabs.map((tab) => tab.label)} className="flex-3 self-start">
-        {tabs.map((tab, index) => (
-          <Panel key={index}>{tab.content}</Panel>
-        ))}
+      <Tabs className="flex-3 self-start">
+        {hasVideo && (
+          <Panel title="Meet the Team">
+            {youtube ? (
+              <YouTube id={youtube} />
+            ) : (
+              <Vimeo id={vimeo} hash={vimeoHash} />
+            )}
+          </Panel>
+        )}
+
+        {Message && (
+          <Panel title="Message from Grant">
+            <Message />
+          </Panel>
+        )}
+        {!Message && about && (
+          <Panel title={`About ${name}`}>
+            <p>{about}</p>
+          </Panel>
+        )}
+
+        {Challenge && (
+          <Panel title="Challenge">
+            <div className="flex flex-col gap-8">
+              <Challenge />
+            </div>
+          </Panel>
+        )}
       </Tabs>
     </div>
   );

--- a/app/pages/talent/PartnerTile.tsx
+++ b/app/pages/talent/PartnerTile.tsx
@@ -1,10 +1,19 @@
+import type { ReactNode } from "react";
 import { href } from "react-router";
 import { ArrowUpRightIcon } from "@phosphor-icons/react";
 import Button from "~/components/Button";
 import { useDarkMode } from "~/components/DarkMode";
 import Link from "~/components/Link";
-import { getPartner, getWordmark, getWordmarkDark } from "./Partner";
-import PartnerTabs from "./PartnerTabs";
+import Tabs, { Panel } from "~/components/Tabs";
+import Vimeo from "~/components/Vimeo";
+import YouTube from "~/components/YouTube";
+import {
+  getChallenge,
+  getMessage,
+  getPartner,
+  getWordmark,
+  getWordmarkDark,
+} from "./Partner";
 
 type Props = {
   // partner id
@@ -12,7 +21,7 @@ type Props = {
 };
 
 // single partner in gallery
-export default function PartnerRow({ id }: Props) {
+export default function PartnerTile({ id }: Props) {
   const darkMode = useDarkMode();
 
   const partner = getPartner(id);
@@ -24,17 +33,60 @@ export default function PartnerRow({ id }: Props) {
     tagline = "",
     location = "",
     apply = "",
+    about = "",
+    youtube = "",
+    vimeo = "",
+    vimeoHash,
   } = partner.frontmatter;
 
   const wordmark = darkMode ? getWordmarkDark(id) : getWordmark(id);
+  const { default: Message } = getMessage(id) ?? {};
+  const { default: Challenge } = getChallenge(id) ?? {};
 
   const page = href("/talent/:id", { id });
 
+  const hasVideo = !!(youtube || vimeo);
+
+  const tabs: { label: string; content: ReactNode }[] = [];
+
+  // interview with team or other video
+  if (hasVideo)
+    tabs.push({
+      label: "Meet the Team",
+      content: youtube ? (
+        <YouTube id={youtube} />
+      ) : (
+        <Vimeo id={vimeo} hash={vimeoHash} />
+      ),
+    });
+
+  // message from grant
+  if (Message)
+    tabs.push({
+      label: "Message from Grant",
+      content: <Message />,
+    });
+  else if (about)
+    tabs.push({
+      label: `About ${name}`,
+      content: <p>{about}</p>,
+    });
+
+  // technical challenge or puzzle
+  if (Challenge)
+    tabs.push({
+      label: "Challenge",
+      content: (
+        <div className="flex flex-col gap-8">
+          <Challenge />
+        </div>
+      ),
+    });
+
   return (
-    <div className="flex items-center gap-12 max-md:flex-col">
+    <div className="flex gap-12 max-md:flex-col">
       {/* identity, high level details */}
-      {/* centers against a video-height panel, but stays put beside a tall one */}
-      <div className="flex flex-2 flex-col items-center gap-6 text-center md:max-h-88 md:justify-center md:self-stretch">
+      <div className="flex flex-2 flex-col items-center justify-center gap-6 text-center md:h-92">
         <Link
           to={page}
           className="flex rounded-md text-black no-underline change-ring hocus:outline-theme"
@@ -69,7 +121,11 @@ export default function PartnerRow({ id }: Props) {
       </div>
 
       {/* rich content, more details */}
-      <PartnerTabs id={id} className="flex-3 self-start" />
+      <Tabs tabs={tabs.map((tab) => tab.label)} className="flex-3 self-start">
+        {tabs.map((tab, index) => (
+          <Panel key={index}>{tab.content}</Panel>
+        ))}
+      </Tabs>
     </div>
   );
 }

--- a/app/pages/talent/Talent.tsx
+++ b/app/pages/talent/Talent.tsx
@@ -3,7 +3,7 @@ import Header from "~/components/Header";
 import Main from "~/components/Main";
 import Meta from "~/components/Meta";
 import TriangleGrid from "~/components/TriangleGrid";
-import Gallery from "./Partners";
+import Gallery from "./Gallery";
 import Questions from "./Questions";
 import TalentHeader from "./TalentHeader";
 

--- a/app/pages/talent/beam/index.mdx
+++ b/app/pages/talent/beam/index.mdx
@@ -32,11 +32,11 @@ import wordmark from "./wordmark-dark.png";
 
 <img src={wordmark} alt="" className="max-h-20 self-center" />
 
-<Tabs tabs={["Meet Our Team", "Learn about BEAM"]}>
-  <Panel>
+<Tabs>
+  <Panel title="Meet Our Team">
     <YouTube id={frontmatter.youtube} />
   </Panel>
-  <Panel>
+  <Panel title="Learn about BEAM">
     <Vimeo id="1177426720" />
   </Panel>
 </Tabs>

--- a/app/pages/talent/cognition/index.mdx
+++ b/app/pages/talent/cognition/index.mdx
@@ -32,14 +32,14 @@ import wordmark from "./wordmark-dark.svg";
 
 <img src={wordmark} alt="" className="max-h-20 self-center" />
 
-<Tabs tabs={["Meet Our Team", "Meet Our Leadership", "How People Use Devin"]}>
-  <Panel>
+<Tabs>
+  <Panel title="Meet Our Team">
     <YouTube id={frontmatter.youtube} />
   </Panel>
-  <Panel>
+  <Panel title="Meet Our Leadership">
     <YouTube id="-pZ3vD0r8a0" />
   </Panel>
-  <Panel>
+  <Panel title="How People Use Devin">
     <YouTube id="AHJ-_uPuJqs" />
   </Panel>
 </Tabs>

--- a/app/pages/talent/doppel/index.mdx
+++ b/app/pages/talent/doppel/index.mdx
@@ -31,11 +31,11 @@ import wordmark from "./wordmark-dark.svg";
 
 <img src={wordmark} alt="" className="max-h-20 self-center" />
 
-<Tabs tabs={["Meet Our Team", "Engineering at Doppel"]}>
-  <Panel>
+<Tabs>
+  <Panel title="Meet Our Team">
     <YouTube id={frontmatter.youtube} />
   </Panel>
-  <Panel>
+  <Panel title="Engineering at Doppel">
     <YouTube id="qU97dM8kue4" />
   </Panel>
 </Tabs>

--- a/app/pages/talent/janestreet/challenge.mdx
+++ b/app/pages/talent/janestreet/challenge.mdx
@@ -11,12 +11,12 @@ trading scenarios. Of course, we do puzzles for fun too! Here are a few examples
 of the kinds of problems we love, and you can find more on our
 [puzzles page](https://www.janestreet.com/puzzles/).
 
-<Tabs tabs={["Knight Moves", "A Polyhedral Puzzle"]}>
-  <Panel>
+<Tabs>
+  <Panel title="Knight Moves">
     <Image image={knightMovesDesktop} className="max-lg:hidden" />
     <Image image={knightMovesMobile} className="lg:hidden" />
   </Panel>
-  <Panel>
+  <Panel title="A Polyhedral Puzzle">
     <Image image={polyhedralDesktop} className="max-lg:hidden" />
     <Image image={polyhedralMobile} className="lg:hidden" />
   </Panel>

--- a/app/pages/talent/metr/index.mdx
+++ b/app/pages/talent/metr/index.mdx
@@ -33,11 +33,11 @@ import wordmark from "./wordmark-dark.svg";
 
 <img src={wordmark} alt="" className="max-h-20 self-center p-2" />
 
-<Tabs tabs={["Meet Our Team", "Meet our Founder"]}>
-  <Panel>
+<Tabs>
+  <Panel title="Meet Our Team">
     <Vimeo id={frontmatter.vimeo} hash={frontmatter.vimeoHash} />
   </Panel>
-  <Panel>
+  <Panel title="Meet our Founder">
     <YouTube id="jXtk68Kzmms" />
   </Panel>
 </Tabs>

--- a/app/pages/testbed/Testbed.mdx
+++ b/app/pages/testbed/Testbed.mdx
@@ -67,28 +67,26 @@ Wow, $e^{i \pi}$ is really cool!
 
 </PiCreatureDemo>
 
-<Tabs
-  tabs={[
-    "A tale of",
-    <>
-      <PiIcon /> Cities
-    </>,
-    <>Paul Clifford</>,
-  ]}
->
-  <Panel>
+<Tabs>
+  <Panel title="A tale of">
     It was the best of times it was the worst of times. It was the age of
     wisdom, it was the age of foolishness. It was the spring of hope, it was the
     winter of despair.
   </Panel>
-  <Panel>
+  <Panel
+    title={
+      <>
+        <PiIcon /> Cities
+      </>
+    }
+  >
     It was a dark and stormy night. The rain fell in torrents, except at
     occasional intervals, when it was checked by a violent gust of wind which
     swept up the streets (for it is in London that our scene lies), rattling
     along the housetops, and fiercely agitating the scanty flame of the lamps
     that struggled against the darkness.
   </Panel>
-  <Panel>
+  <Panel title={<>Paul Clifford</>}>
     <ShowPartial>
       It was a bright cold day in April, and the clocks were striking thirteen.
       Winston Smith, his chin nuzzled into his breast in an effort to escape the

--- a/app/pages/testbed/Testbed.mdx
+++ b/app/pages/testbed/Testbed.mdx
@@ -67,7 +67,7 @@ Wow, $e^{i \pi}$ is really cool!
 
 </PiCreatureDemo>
 
-<Tabs>
+<Tabs defaultIndex={1}>
   <Panel title="A tale of">
     It was the best of times it was the worst of times. It was the age of
     wisdom, it was the age of foolishness. It was the spring of hope, it was the


### PR DESCRIPTION
- change tabs component api shape: tab title defined right on panel content instead of as separate prop. this makes conditional rendering cleaner.
- change all usage points of tabs component
- get rid of ShowPartial around "message from grant"?
- rename some components
- merge PartnerTabs just back directly into PartnerTile now that it's only used there
- simplify partner tile css, polish alignment