### PR TITLE
Comment on pr with details about e2e test failures

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -82,6 +82,8 @@ jobs:
 
   test-e2e:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -102,6 +104,46 @@ jobs:
       - name: Run test
         run: bun run test:e2e
 
+      - name: Parse results
+        if: failure()
+        id: parse-results
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require("fs");
+            const reportPath = "playwright-report/json/results.json";
+            if (!fs.existsSync(reportPath)) return;
+            const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+            const specs = report.suites?.flatMap((suite) => suite.specs ?? []) ?? [];
+            const details = (title, body) =>
+              `<details><summary>${title}</summary>\n\n${body}\n\n</details>`;
+            const sections = specs.flatMap(({ file, title, tests }) =>
+              tests
+                .filter(({ status }) => status === "unexpected")
+                .map(({ annotations }) =>
+                  details(
+                    `\`${file}\` - ${title}`,
+                    annotations
+                      .map(({ type, description = "" }) =>
+                        details(type, `\`\`\`json\n${description}\n\`\`\``),
+                      )
+                      .join("\n\n"),
+                  ),
+                ),
+            );
+            if (!sections.length) return;
+            core.setOutput(
+              "body",
+              ["**End-to-end test failures**", ...sections].join("\n\n"),
+            );
+
+      - name: Post comment
+        if: success() || steps.parse-results.outputs.body
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          message: ${{ steps.parse-results.outputs.body }}
+          delete: ${{ success() }}
+
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v6
@@ -109,5 +151,4 @@ jobs:
           name: reports
           path: |
             ./playwright-report
-            ./lighthouse-report
           retention-days: 30

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -113,13 +113,9 @@ jobs:
           script: |
             const fs = require("fs");
             const reportPath = "playwright-report/json/results.json";
-            if (!fs.existsSync(reportPath)) {
-              console.log(`No report found at ${reportPath}`);
-              return;
-            }
+            if (!fs.existsSync(reportPath)) return;
             const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
             const specs = report.suites?.flatMap((suite) => suite.specs ?? []) ?? [];
-            console.log(`Found ${specs.length} specs`);
             const details = (title, body) =>
               `<details><summary>${title}</summary>\n\n${body}\n\n</details>`;
             const sections = specs.flatMap(({ file, title, tests }) =>
@@ -136,11 +132,11 @@ jobs:
                   ),
                 ),
             );
-            console.log(`Found ${sections.length} unexpected test sections`);
             if (!sections.length) return;
-            const body = ["**End-to-end test failures**", ...sections].join("\n\n");
-            console.log(`Body length: ${body.length}`);
-            core.setOutput("body", body);
+            core.setOutput(
+              "body",
+              ["**End-to-end test failures**", ...sections].join("\n\n"),
+            );
 
       - name: Post comment
         if: >-

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -143,7 +143,9 @@ jobs:
             core.setOutput("body", body);
 
       - name: Post comment
-        if: steps.test.outcome == 'success' || steps.parse-results.outputs.body
+        if: >-
+          !cancelled() &&
+          (steps.test.outcome == 'success' || steps.parse-results.outputs.body)
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           message: ${{ steps.parse-results.outputs.body }}

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -102,6 +102,7 @@ jobs:
         run: bun run install-playwright
 
       - name: Run test
+        id: test
         run: bun run test:e2e
 
       - name: Parse results
@@ -138,11 +139,11 @@ jobs:
             );
 
       - name: Post comment
-        if: success() || steps.parse-results.outputs.body
+        if: steps.test.outcome == 'success' || steps.parse-results.outputs.body
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           message: ${{ steps.parse-results.outputs.body }}
-          delete: ${{ success() }}
+          delete: ${{ steps.test.outcome == 'success' }}
 
       - name: Upload test reports
         if: always()

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -123,7 +123,7 @@ jobs:
                 .filter(({ status }) => status === "unexpected")
                 .map(({ annotations }) =>
                   details(
-                    `\`${file}\` - ${title}`,
+                    `<code>${file}</code> - ${title}`,
                     annotations
                       .map(({ type, description = "" }) =>
                         details(type, `\`\`\`json\n${description}\n\`\`\``),

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -113,9 +113,13 @@ jobs:
           script: |
             const fs = require("fs");
             const reportPath = "playwright-report/json/results.json";
-            if (!fs.existsSync(reportPath)) return;
+            if (!fs.existsSync(reportPath)) {
+              console.log(`No report found at ${reportPath}`);
+              return;
+            }
             const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
             const specs = report.suites?.flatMap((suite) => suite.specs ?? []) ?? [];
+            console.log(`Found ${specs.length} specs`);
             const details = (title, body) =>
               `<details><summary>${title}</summary>\n\n${body}\n\n</details>`;
             const sections = specs.flatMap(({ file, title, tests }) =>
@@ -132,11 +136,11 @@ jobs:
                   ),
                 ),
             );
+            console.log(`Found ${sections.length} unexpected test sections`);
             if (!sections.length) return;
-            core.setOutput(
-              "body",
-              ["**End-to-end test failures**", ...sections].join("\n\n"),
-            );
+            const body = ["**End-to-end test failures**", ...sections].join("\n\n");
+            console.log(`Body length: ${body.length}`);
+            core.setOutput("body", body);
 
       - name: Post comment
         if: steps.test.outcome == 'success' || steps.parse-results.outputs.body

--- a/app/pages/home/Home.tsx
+++ b/app/pages/home/Home.tsx
@@ -33,6 +33,7 @@ export default function Home() {
       </Header>
 
       <Main>
+        <img src="/images/egg.png" />
         <Hero />
         <Lessons />
         <Patreon />

--- a/app/pages/home/Home.tsx
+++ b/app/pages/home/Home.tsx
@@ -33,7 +33,6 @@ export default function Home() {
       </Header>
 
       <Main>
-        <img src="/images/egg.png" />
         <Hero />
         <Lessons />
         <Patreon />

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,11 +2,21 @@ import { defineConfig, devices } from "@playwright/test";
 
 const port = 31415;
 const url = `http://localhost:${port}`;
+const { CI } = process.env;
 
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
-  reporter: [["html", { open: process.env.CI ? "never" : "on-failure" }]],
+  reporter: [
+    ["json", { outputFile: "playwright-report/json/results.json" }],
+    [
+      "html",
+      {
+        outputFolder: "playwright-report/html",
+        open: CI ? "never" : "on-failure",
+      },
+    ],
+  ],
 
   use: {
     baseURL: url,


### PR DESCRIPTION
This should make it easier to see and fix end-to-end test failures by posting the details in a comment on the PR. ~I added an intentional error on the home page to test this change, which I should remove before merge.~

It's deleted now because I removed the fake error, but here's a taste of the comment that now gets generated when there's an e2e failure:

<img height="200" alt="Screenshot 2026-08-31 at 2 44 58 PM" src="https://github.com/user-attachments/assets/aac1e7c6-e8df-40b4-9761-c66bcef5f5a4" />
