### PR TITLE
Fix squished Figure images in Safari on Talent partner pages

### DIFF
--- a/app/components/Figure.tsx
+++ b/app/components/Figure.tsx
@@ -30,19 +30,17 @@ export default function Figure({
   children,
 }: Props) {
   // image to render
-  //
-  // when there's no caption, Image renders a bare <img>, which (as a direct
-  // flex item of the surrounding section) hits a Safari bug where percentage
-  // width + auto height loses the intrinsic aspect ratio once the section's
-  // width is clamped. wrapping in a block-level div keeps the img out of the
-  // flex layout and sidesteps it.
   const imageElement = children ? (
     <Image image={image ?? ""} className={clsx("w-full", className)}>
       {children}
     </Image>
   ) : (
-    <div className={clsx("w-full", className)}>
-      <Image image={image ?? ""} className="block h-auto w-full" />
+    // wrapper keeps img out of parent flex layout, where Safari loses its aspect ratio
+    <div className="w-full">
+      <Image
+        image={image ?? ""}
+        className={clsx("block h-auto w-full", className)}
+      />
     </div>
   );
 

--- a/app/components/Figure.tsx
+++ b/app/components/Figure.tsx
@@ -30,10 +30,20 @@ export default function Figure({
   children,
 }: Props) {
   // image to render
-  const imageElement = (
+  //
+  // when there's no caption, Image renders a bare <img>, which (as a direct
+  // flex item of the surrounding section) hits a Safari bug where percentage
+  // width + auto height loses the intrinsic aspect ratio once the section's
+  // width is clamped. wrapping in a block-level div keeps the img out of the
+  // flex layout and sidesteps it.
+  const imageElement = children ? (
     <Image image={image ?? ""} className={clsx("w-full", className)}>
       {children}
     </Image>
+  ) : (
+    <div className={clsx("w-full", className)}>
+      <Image image={image ?? ""} className="block h-auto w-full" />
+    </div>
   );
 
   // video to render

--- a/app/pages/talent/janestreet/index.mdx
+++ b/app/pages/talent/janestreet/index.mdx
@@ -16,6 +16,7 @@ about: Everybody here is a math nerd. If you go up to someone and start explaini
 
 import { ArrowUpRightIcon } from "@phosphor-icons/react";
 import Button from "~/components/Button";
+import Figure from "~/components/Figure";
 import Image from "~/components/Image";
 import Quote from "~/components/Quote";
 import Tabs, { Panel } from "~/components/Tabs";
@@ -68,7 +69,7 @@ We're building a truly AI-driven trading firm, rooted in frontier research and d
 
 ## Machine Learning/Trading/Quantitative Research
 
-<Image image={whiteboardWide} className="w-full" />
+<Figure image={whiteboardWide} />
 
 On our Machine Learning team, you'll build the deep learning models that power our trading strategies, supported by thousands of high-end GPUs. Financial markets pose unique challenges for machine learning: extreme noise, nonstationarity, and a competitive multi-agent environment. Our researchers have to be up on the latest developments in the field, as well as pursuing novel techniques.
 


### PR DESCRIPTION
Captionless Figure images render a bare <img> as a direct flex item of the page section, which hits a Safari bug where percentage width + auto height loses the intrinsic aspect ratio once the section's width is clamped. Wrapping in a block-level div keeps the img out of the flex layout and avoids it.