### PR TITLE
Fix 'Compression is Intelligence' title

### DIFF
--- a/app/pages/lessons/2026/entropy/index.mdx
+++ b/app/pages/lessons/2026/entropy/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reinventing Entropy | Compression & Intelligence Part 1
+title: Reinventing Entropy | Compression is Intelligence Part 1
 description: What is the fundamental compressibility of language?
 date: "2026-06-07"
 video: l6DKRf-fAAM


### PR DESCRIPTION
## Summary

- Change the Part 1 lesson title from “Compression & Intelligence” to “Compression is Intelligence”
- Match the title shown in the video and the existing Part 2 series naming

## Checks

- `git diff --check`
- Prettier 3.9.5 check for `app/pages/lessons/2026/entropy/index.mdx`
