### PR TITLE
simpler fix for image stretch

### DIFF
--- a/app/components/Figure.tsx
+++ b/app/components/Figure.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import { ImageIcon, VideoIcon } from "@phosphor-icons/react";
-import clsx from "clsx";
 import Image from "~/components/Image";
 import Tabs, { Panel } from "~/components/Tabs";
 import { usePrinting } from "~/util/hooks";
@@ -30,18 +29,10 @@ export default function Figure({
   children,
 }: Props) {
   // image to render
-  const imageElement = children ? (
-    <Image image={image ?? ""} className={clsx("w-full", className)}>
+  const imageElement = (
+    <Image image={image ?? ""} className={className}>
       {children}
     </Image>
-  ) : (
-    // wrapper keeps img out of parent flex layout, where Safari loses its aspect ratio
-    <div className="w-full">
-      <Image
-        image={image ?? ""}
-        className={clsx("block h-auto w-full", className)}
-      />
-    </div>
   );
 
   // video to render


### PR DESCRIPTION
Supercedes #700

I believe this still fixes the issue, which I was primarily seeing here:

<img height="200" alt="Screenshot 2026-09-02 at 11 20 09 AM" src="https://github.com/user-attachments/assets/20b4d7f4-9cc2-4c42-a828-7b630999d32f" />

Spot checking other instances of `<Figure />`

I think this is a good example of how LLMs try to fix by adding instead of removing. The `w-full` on the image element may have been a vestigial, unnecessary style. I was probably trying to make sure even small images (e.g. 100px wide) would still stretch to fill the width of the container. But since the container (whether it be a `<section>` or a tab `<Panel>`) should always be a `flex flex-col` container, and since flex defaults to `align-items: stretch`, the container should ensure full width anyway. Even if the container had `items-center`, you could apply `self-stretch` to the image to ensure it gets full width.

This may be a small simplification in the grand scheme of things, but I view my role in this as fighting against slow accumulation of entropy in the code, to avoid ending up with workaround's piled on top of workarounds.

As for why Safari does this, that's still a mystery to me. But I've often found that over-specifying things (e.g. adding `w-full` when the parent would already ensure that) can confuse the browser more, especially Safari.